### PR TITLE
larger keyboard on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
     >
       <header>
         <div class="nav">
-          <a href="#" class="nav-link" x-show="page !== ''">
+          <a href="#" class="nav-link" x-show="page !== ''" x-cloak>
             <i class="material-icons">arrow_back</i>
           </a>
         </div>
@@ -102,28 +102,30 @@
               </div>
             </div>
           </template>
-          <div class="hint-area">
-            <button
-              class="hint-button"
-              @click="showHint"
-              x-show="hint.available"
-              x-transition:enter.duration.500ms
-              x-cloak
-            >
-              Need a hint?
-            </button>
-            <div
-              class="hint"
-              x-show="hint.message"
-              @click="resetHint"
-              x-transition:enter.duration.1000ms
-              x-transition:leave.duration.500ms
-            >
-              <span x-text="hint.message"></span>
-            </div>
+        </div>
+
+        <div class="hint-area">
+          <button
+            class="hint-button"
+            @click="showHint"
+            x-show="hint.available"
+            x-transition:enter.duration.500ms
+            x-cloak
+          >
+            Need a hint?
+          </button>
+          <div
+            class="hint"
+            x-show="hint.message"
+            @click="resetHint"
+            x-transition:enter.duration.1000ms
+            x-transition:leave.duration.500ms
+          >
+            <span x-text="hint.message"></span>
           </div>
         </div>
-        <div class="keyboard">
+
+        <div class="bottom-area">
           <div
             x-show="solved"
             x-cloak
@@ -142,21 +144,36 @@
             <p x-text="target"></p>
           </div>
           <template x-if="!solved && !failed">
-            <template x-for="letter in keyboard">
-              <div
-                class="key"
-                x-text="letter.label"
-                :class="[settings.case, 'key-' + letter.type, letter.state, letter.label === hint.letter ? 'glow' : '']"
-                @click="addLetter(letter)"
-              ></div>
-            </template>
+            <div class="keyboard-grid">
+              <template x-for="letter in keyboard">
+                <div
+                  role="button"
+                  tabindex="0"
+                  class="key"
+                  :class="[settings.case, 'key-' + letter.type, letter.state, letter.label === hint.letter ? 'pulse' : '']"
+                  @click="addLetter(letter)"
+                >
+                  <template x-if="letter.type === 'letter'">
+                    <span x-text="letter.label"></span>
+                  </template>
+                  <template x-if="letter.type === 'back'">
+                    <span class="material-icons">backspace</span>
+                  </template>
+                  <template x-if="letter.type === 'enter'">
+                    <span class="material-icons">check_circle</span>
+                  </template>
+                </div>
+              </template>
+            </div>
           </template>
         </div>
       </div>
-      <div class="help-content" x-show="page === '#help'">
+
+      <div class="help-content" x-show="page === '#help'" x-cloak>
         <h1>Help</h1>
       </div>
-      <div class="collection-content" x-show="page === '#collection'">
+
+      <div class="collection-content" x-show="page === '#collection'" x-cloak>
         <h1>Collection</h1>
         <p x-show="unlockedEmojis.length === 0">
           Your word guesses can unlock hidden emojis.<br />Maybe you'll find one
@@ -204,7 +221,8 @@
           </template>
         </div>
       </div>
-      <div class="settings-content" x-show="page === '#settings'">
+
+      <div class="settings-content" x-show="page === '#settings'" x-cloak>
         <h1>Settings</h1>
         <div>
           <h2>Difficulty</h2>
@@ -338,7 +356,7 @@
         keyboardLayout: "atoz", // atoz, qwerty
         case: "lowercase", // lowercase, uppercase
       };
-      const HINT_DELAY = 10 * 1000;
+      const HINT_DELAY = 15 * 1000;
 
       return {
         page: location.hash,

--- a/public/main.css
+++ b/public/main.css
@@ -8,7 +8,7 @@ body {
   font-family: "Andika New Basic", sans-serif;
   height: 100%;
   margin: 0;
-  padding: 1rem;
+  padding: 0;
 }
 
 * {
@@ -25,8 +25,14 @@ header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-bottom: 1px #818384 solid;
-  padding: 0 0 1.2rem;
+  border-bottom: 1px solid #818384;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+@media screen and (min-width: 600px) {
+  header {
+    padding: 1rem 0;
+  }
 }
 
 .nav-link {
@@ -63,48 +69,43 @@ a {
 }
 
 .game-content {
+  padding: 4px;
   display: flex;
   flex-direction: column;
-  height: calc(100% - 50px);
   justify-content: space-around;
 }
 
-.keyboard {
-  user-select: none;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  justify-content: center;
-  margin: 0 auto 20px;
+.keyboard-grid {
+  display: grid;
+  gap: 4px;
+  grid-template-rows: repeat(4, minmax(40px, 1fr));
+  grid-template-columns: repeat(7, minmax(36px, 1fr));
   font-size: 1.5rem;
+  user-select: none;
 }
-
-.key {
+.keyboard-grid .key {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 4px;
   background-color: #818384;
   color: white;
-  text-align: center;
   cursor: pointer;
-  width: 30px;
-  line-height: 42px;
 }
-.key-enter {
-  min-width: 80px;
-  text-transform: capitalize;
+.keyboard-grid .key-letter span {
+  transform: translateY(-0.1em); /* make j etc look more centered */
 }
-.key-back {
-  min-width: 60px;
+.key.available:hover {
+  background: #747677;
 }
+
 @media screen and (min-width: 600px) {
-  .keyboard {
+  .keyboard-grid {
     gap: 8px;
+    max-width: 400px;
+    margin: 0 auto;
   }
-  .key {
-    line-height: 62px;
-    width: 40px;
-  }
-  .key-letter,
-  .key-back {
+  .keyboard-grid .key {
     font-size: 2rem;
   }
 }
@@ -113,7 +114,9 @@ a {
   display: flex;
   justify-content: center;
   gap: 8px;
-  margin-bottom: 8px;
+}
+.guesses-word + .guesses-word {
+  margin-top: 8px;
 }
 
 .guesses-tile {
@@ -166,11 +169,12 @@ a {
 }
 
 .hint-area {
-  min-height: 26px;
+  min-height: 52px;
   font-size: 1rem;
   color: #999;
   display: flex;
   justify-content: center;
+  align-items: center;
 }
 .hint-button {
   font-size: 1rem;
@@ -193,26 +197,25 @@ a {
   font-size: 2rem;
 }
 
-.unavailable {
+.key.unavailable,
+.guesses-tile.unavailable {
   background-color: #81837b6e;
   cursor: auto;
 }
 
-.miss {
+.key.miss,
+.guesses-tile.miss {
   background-color: #81837b6e;
 }
 
-.present {
+.key.present,
+.guesses-tile.present {
   background-color: #b59f3b;
 }
 
-.match {
+.key.match,
+.guesses-tile.match {
   background-color: #538d4e;
-}
-
-.glow {
-  box-shadow: 0 0 2px 1px #fff, /* inner white */ 0 0 3px 2px #f0f,
-    /* middle magenta */ 0 0 4px 3px #0ff; /* outer cyan */
 }
 
 /* animations */


### PR DESCRIPTION
The buttons were not wide enough on my phone... if we want qwerty mode to line up correctly, would need to tweak this some more

- x-cloak to avoid "flashes of unstyled content" on page load
- increased delay before hint shows
- add role button so we use keyboard to tab through the keyboard UI
- replaced hint highlight with existing pulse animation

# mobile

![image](https://user-images.githubusercontent.com/438545/151722401-ebd1ab39-9bec-450e-af68-f9fb79040e7d.png)

# desktop

![image](https://user-images.githubusercontent.com/438545/151722414-65e86959-3bb6-4f77-8841-fdd92ba96760.png)
