### PR TITLE
show unlock notice instead of emoji tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,21 +104,14 @@
         </div>
       </div>
     </header>
-    <main>
+    <main :class="`target-${target.length}`">
       <div class="game-content" x-show="page === ''">
-        <div class="guesses-grid" :class="`target-${target.length}`">
+        <div class="guesses-grid">
           <template
             x-for="(guess, guessIndex) in guesses"
             :key="`${level}-${guessIndex}`"
           >
             <div class="guesses-row" :class="settings.case">
-              <div class="guesses-tile emoji-tile">
-                <span
-                  x-text="guessEmojis[guessIndex]"
-                  x-show="guessEmojis[guessIndex]"
-                  x-transition.delay.2000ms
-                ></span>
-              </div>
               <template x-for="(letter, letterIndex) in guess">
                 <div
                   class="guesses-tile"
@@ -132,13 +125,6 @@
                   ></span>
                 </div>
               </template>
-              <div class="guesses-tile emoji-tile">
-                <span
-                  x-text="guessEmojis[guessIndex]"
-                  x-show="guessEmojis[guessIndex]"
-                  x-transition.delay.2000ms
-                ></span>
-              </div>
             </div>
           </template>
         </div>
@@ -174,7 +160,7 @@
         <div
           x-cloak
           x-show="failed"
-          x-transition.duration.1000ms
+          x-transition:enter.duration.1000ms
           class="defeat"
         >
           Nice try! It was:
@@ -474,11 +460,7 @@
               return;
             }
             if (this.isCurrentWordInvalid()) {
-              window.dispatchEvent(
-                new CustomEvent("notice", {
-                  detail: { text: "Not a valid word" },
-                })
-              );
+              this.showNotice("Check your spelling... 🤔");
               return;
             }
             this.currentGuess.forEach(
@@ -527,6 +509,7 @@
             this.currentGuess[i].state = letterResult;
           });
           this.updateKeyboardForGuess(this.currentWord);
+          this.checkEmojiGuess();
           this.addToCollection(this.currentWord);
           this.solved = this.currentWord === this.target;
           this.currentGuessIndex += 1;
@@ -541,6 +524,15 @@
           ) {
             this.failed = true;
             this.levelEnd();
+          }
+        },
+        checkEmojiGuess() {
+          const emoji = emojis[this.currentWord];
+          const alreadyFound = this.unlockedEmojis.some(
+            (entry) => entry.word === this.currentWord
+          );
+          if (emoji && !alreadyFound) {
+            this.showNotice(`You unlocked ${emoji} !`);
           }
         },
         updateKeyboardForGuess(guess) {
@@ -593,7 +585,7 @@
           backKey.state = this.cursor > 0 ? "available" : "unavailable";
           enterKey.state =
             this.isCurrentWordComplete() && !this.isCurrentWordInvalid()
-              ? "available pulse"
+              ? "available pulse-small"
               : "unavailable";
         },
         keyPressed(e) {
@@ -732,6 +724,13 @@
           this.hint.letter = hint.letter;
           this.hint.available = false;
         },
+        showNotice(text) {
+          window.dispatchEvent(
+            new CustomEvent("notice", {
+              detail: { text },
+            })
+          );
+        },
         initialLoad() {
           this.loadSettings();
           this.loadGameState();
@@ -791,9 +790,7 @@
         },
         updateSettings() {
           this.saveSettings();
-          window.dispatchEvent(
-            new CustomEvent("notice", { detail: { text: "Settings updated" } })
-          );
+          this.showNotice("Settings updated");
         },
         updateDifficulty(e) {
           this.saveSettings();
@@ -926,11 +923,7 @@
             navigator.share(shareData);
           } else if (navigator?.clipboard) {
             navigator.clipboard.writeText(`${title}\n${text}\n${url}`);
-            window.dispatchEvent(
-              new CustomEvent("notice", {
-                detail: { text: "Copied to clipboard" },
-              })
-            );
+            this.showNotice("Copied to clipboard");
           }
           amplitude.getInstance().logEvent("clicked_share", {
             page: this.page,
@@ -956,7 +949,7 @@
           notice.id = Date.now();
           notice.visible = true;
           this.notice = notice;
-          const timeShown = 5000;
+          const timeShown = 5 * 1000;
           setTimeout(() => {
             this.remove(notice.id);
           }, timeShown);

--- a/public/main.css
+++ b/public/main.css
@@ -159,17 +159,20 @@ main {
   padding: 8px;
 }
 
-.target-5 .guesses-row {
-  --guess-columns: calc(5 + 2);
+.target-4 {
+  --guess-columns: 4;
 }
-.target-6 .guesses-row {
-  --guess-columns: calc(6 + 2);
+.target-5 {
+  --guess-columns: 5;
+}
+.target-6 {
+  --guess-columns: 6;
 }
 .guesses-row {
   display: flex;
   justify-content: center;
   gap: var(--tile-spacing);
-  aspect-ratio: var(--guess-columns, 6) / 1;
+  aspect-ratio: var(--guess-columns, 4) / 1;
   margin: 0 auto;
   --margin-between-rows: calc(var(--total-guesses) * var(--tile-spacing));
   height: calc(calc(100% - var(--margin-between-rows)) / var(--total-guesses));
@@ -260,7 +263,7 @@ main {
 
 .key {
   transition: background 0.5s;
-  transition-delay: 1s;
+  transition-delay: calc(0.25s * var(--guess-columns));
   flex-grow: 1;
   border-radius: 15px;
   background-color: var(--color-available);
@@ -427,15 +430,16 @@ main {
 
 .notice {
   position: fixed;
+  top: 8%;
+  bottom: auto;
+  left: 50%;
+  transform: translateX(-50%);
   min-width: 250px;
   z-index: 1;
-  bottom: 15px;
-  left: 50%;
   text-align: center;
   align-items: center;
   border-radius: 15px;
-  padding: 4px;
-  transform: translateX(-50%);
+  padding: 8px 16px;
   font-size: 1.5rem;
   color: var(--color-notice-text);
   background-color: var(--color-notice-bg);
@@ -444,7 +448,10 @@ main {
 /* animations */
 
 .pulse {
-  animation: pulse 0.5s linear infinite alternate;
+  animation: grow 0.5s linear infinite alternate;
+}
+.pulse-small {
+  animation: grow-small 0.5s linear infinite alternate;
 }
 .pop {
   animation: pop 0.3s;
@@ -453,12 +460,21 @@ main {
   animation: fadein 0.5s;
 }
 
-@keyframes pulse {
+@keyframes grow {
   0% {
     transform: scale(1);
   }
   100% {
     transform: scale(1.1);
+  }
+}
+
+@keyframes grow-small {
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(1.05);
   }
 }
 


### PR DESCRIPTION
misc other fixes:
- make keyboard animation delay vary with length
- hide failure message immediately when switching to other difficulties
- don't pulse "guess" button as wide (it's too big for that)

Helps with #43 

<img width="543" alt="image" src="https://user-images.githubusercontent.com/438545/154784399-bd7115fc-ad0c-409c-a95e-1e858e85d988.png">
