### PR TITLE
Change keys into a tailwind component

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,12 +176,12 @@
         <div class="keyboard">
           <template x-if="!solved && !failed">
             <template x-for="letter in keyboard" :key="level + letter.label">
-              <div
+              <button
                 class="key"
                 x-text="letter.label"
                 :class="[settings.case, 'key-' + letter.type, letter.state, letter.label === hint.letter ? 'pulse' : '']"
                 @click="addLetter(letter)"
-              ></div>
+              ></button>
             </template>
           </template>
         </div>

--- a/public/input.css
+++ b/public/input.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .key {
+    @apply h-14 w-8 text-black rounded-xl border-2 border-gray-900 text-center text-2xl bg-spellie-blue-dark;
+  }
+}
+
 :root {
   /* TODO: extract others */
   --color-neutral-0: #000;
@@ -90,16 +96,6 @@ a {
   font-size: 1.5rem;
 }
 
-.key {
-  border-radius: 15px;
-  background-color: #08adff;
-  border: 2px solid var(--color-neutral-10);
-  color: black;
-  text-align: center;
-  cursor: pointer;
-  width: 30px;
-  line-height: 42px;
-}
 .key-enter {
   min-width: 80px;
   text-transform: capitalize;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   content: ["index.html", "./public/**/*.{html,js}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        "spellie-blue-dark": "#08adff",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
As the title says, trying to demonstrate how this code would look if tailwindcss is introduced to this codebase
![image](https://user-images.githubusercontent.com/2354516/154794337-dcc43c19-dfe5-4de8-854b-041a9e3072c8.png)
Ignore the keyboard layout i'm making another PR to show why css grid will make the keyboard layout difficult and we should use flexbox, but you can see what the buttons look like after I replaced the old key class with a new one built out of tailwind classes.

P.S. - didn't want to stomp all over your PR Chris so I made a new one to merge into the one you've started