### PR TITLE
Can we build the keyboard using grid?

### DIFF
--- a/public/input.css
+++ b/public/input.css
@@ -88,12 +88,28 @@ a {
 
 .keyboard {
   user-select: none;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  justify-content: center;
-  margin: 0 auto 8px;
-  font-size: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 0.25rem;
+}
+
+/* Kind of redundant, here for completeness */
+.keyboard > button:nth-child(-1n + 12) {
+  grid-row-start: 1;
+}
+
+.keyboard > button:nth-child(n + 13) {
+  grid-row-start: 2;
+}
+
+.keyboard > button:nth-child(n + 22) {
+  grid-row-start: 3;
+}
+
+.keyboard > button:nth-last-child(2),
+.keyboard > button:nth-last-child(1) {
+  grid-row-start: 4;
+  grid-column: span 3;
 }
 
 .key-enter {


### PR DESCRIPTION
tl;dr: I don't think we could.

![image](https://user-images.githubusercontent.com/2354516/154794601-9d8d95f7-3455-4c70-b731-f6203503cb3a.png)

So....initially I wanted to change the html such that there would be a `row` div which housed all the keys. Kind of something like this.
```html
<div class='keyboard'>
   <div class='row'>
      top row of keys
   </div>
   <div class='row'>
      spacer
      middle row of keys
      spacer
   </div>
   <div class='row'>
      spacer
      bottom row of keys
      spacer
   </div>
</div>
```

But having looked at the code I don't think that's possible without rewriting some pretty important pieces of the game logic, which expect keyboard being an array of `{ type, label, state }` objects. Instead of doing that (cause I didn't want to read through all this js) or creating a new array in the shape I want purely for rendering purposes (not an awful idea but keeping state between these 2 different keyboard arrays in sync seems like a problem best avoided) I wanted to see if we could do this purely with css grid. tldr; we can't because grids want you to have an even number of columns for each row (cause y'know its a grid). You can _kind_ of fake it... I got each row to show the correct letters but getting things to be centered horizontally won't work because you'd have to render keys over grid lines, which css grid doesn't let you do.