### PR TITLE
Adding a reveal and reset button

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,11 +175,11 @@
           /></a>
         </div>
       </div>
-      <div class="game-content" x-show="page === ''">
+      <div class="game-content" x-show="page === ''" x-ref="gameContent">
         <div class="guesses-grid">
           <template
             x-for="(guess, guessIndex) in guesses"
-            :key="`${level}-${guessIndex}`"
+            :key="`${level}-${attempt}-${guessIndex}`"
           >
             <div class="guesses-row" :class="settings.case">
               <template x-for="(letter, letterIndex) in guess">
@@ -190,7 +190,7 @@
                 >
                   <span
                     x-show="letter.letter"
-                    x-text="letter.letter"
+                    x-text="masked ? '' : letter.letter"
                     x-transition:enter="pop"
                   ></span>
                 </div>
@@ -217,7 +217,7 @@
             <span x-text="hint.message"></span>
           </div>
         </div>
-        <div x-show="solved" x-cloak>
+        <div x-show="solved && !masked" x-cloak>
           <div
             x-transition.enter.duration.1000ms
             x-transition.leave.duration.0ms
@@ -228,23 +228,31 @@
         </div>
         <div
           x-cloak
-          x-show="failed"
+          x-show="failed && !masked"
           x-transition:enter.duration.1000ms
           class="defeat"
         >
           Nice try! It was:
           <p x-text="target"></p>
         </div>
+        <div x-cloak x-show="masked" class="">
+          <div @click="resetLevel">
+            <span>Reset</span><i class="material-icons">replay</i>
+          </div>
+          <div @click="unmask">
+            <span>Reveal</span><i class="material-icons">visibility</i>
+          </div>
+        </div>
         <div class="keyboard">
           <template x-if="!solved && !failed">
             <template
               x-for="(keyboardRow, rowIndex) in keyboard"
-              :key="level + rowIndex"
+              :key="`${level}-${attempt}-${rowIndex}`"
             >
               <div class="keyboard-row">
                 <template
                   x-for="letter in keyboardRow"
-                  :key="level + letter.label"
+                  :key="`${level}-${attempt}-${letter.label}`"
                 >
                   <div
                     class="key"
@@ -514,7 +522,9 @@
         guesses: [],
         solved: false,
         failed: false,
+        masked: false,
         hint: DEFAULT_HINT,
+        attempt: 0,
         currentGuessIndex: 0,
         cursor: 0,
         cursorMode: false,
@@ -826,6 +836,7 @@
               emptyGuesses(this.target.length, maxGuesses);
             this.solved = initialState.solved || false;
             this.failed = initialState.failed || false;
+            this.masked = this.solved || this.failed;
             this.currentGuessIndex = initialState.currentGuessIndex || 0;
             this.cursor = initialState.cursor || 0;
             this.cursorMode = initialState.cursorMode || false;
@@ -927,6 +938,14 @@
         },
         get unlockedEmojis() {
           return this.emojiCollection?.filter((e) => e.unlocked);
+        },
+        resetLevel() {
+          localStorage.removeItem(`game-state-${this.settings.difficulty}`);
+          this.attempt += 1;
+          this.loadGameState();
+        },
+        unmask() {
+          this.masked = false;
         },
         toJson() {
           return {

--- a/index.html
+++ b/index.html
@@ -175,11 +175,11 @@
           /></a>
         </div>
       </div>
-      <div class="game-content" x-show="page === ''" x-ref="gameContent">
+      <div class="game-content" x-show="page === ''">
         <div class="guesses-grid">
           <template
             x-for="(guess, guessIndex) in guesses"
-            :key="`${level}-${attempt}-${guessIndex}`"
+            :key="`${gameId}-${guessIndex}`"
           >
             <div class="guesses-row" :class="settings.case">
               <template x-for="(letter, letterIndex) in guess">
@@ -217,7 +217,7 @@
             <span x-text="hint.message"></span>
           </div>
         </div>
-        <div x-show="solved && !masked" x-cloak>
+        <div x-show="solved && endGame" x-cloak>
           <div
             x-transition.enter.duration.1000ms
             x-transition.leave.duration.0ms
@@ -228,18 +228,21 @@
         </div>
         <div
           x-cloak
-          x-show="failed && !masked"
+          x-show="failed && endGame"
           x-transition:enter.duration.1000ms
           class="defeat"
         >
           Nice try! It was:
           <p x-text="target"></p>
         </div>
-        <div x-cloak x-show="masked" class="masked-game-buttons">
-          <button @click="unmask">
+        <div x-cloak x-show="showResetButtons" class="masked-game-buttons">
+          <button aria-label="Reveal" @click="unmask" x-show="masked">
             Reveal <i class="material-icons">visibility</i>
           </button>
-          <button @click="resetLevel">
+          <button aria-label="Hide" @click="mask" x-show="!masked">
+            Hide <i class="material-icons">visibility_off</i>
+          </button>
+          <button aria-label="Reset" @click="resetLevel">
             Reset <i class="material-icons">replay</i>
           </button>
         </div>
@@ -247,12 +250,12 @@
           <template x-if="!solved && !failed">
             <template
               x-for="(keyboardRow, rowIndex) in keyboard"
-              :key="`${level}-${attempt}-${rowIndex}`"
+              :key="`${gameId}-${rowIndex}`"
             >
               <div class="keyboard-row">
                 <template
                   x-for="letter in keyboardRow"
-                  :key="`${level}-${attempt}-${letter.label}`"
+                  :key="`${gameId}-${letter.label}`"
                 >
                   <div
                     class="key"
@@ -523,8 +526,10 @@
         solved: false,
         failed: false,
         masked: false,
+        endGame: false,
+        gameId: 0,
+        showResetButtons: false,
         hint: DEFAULT_HINT,
-        attempt: 0,
         currentGuessIndex: 0,
         cursor: 0,
         cursorMode: false,
@@ -824,6 +829,8 @@
             if (initialState.puzzleId !== this.puzzleId) {
               initialState = {};
             }
+            // Create a unique id for each game state so that we redraw the grid and keyboard properly
+            this.gameId += 1;
             this.level =
               initialState.level ||
               `${this.settings.difficulty}-${this.puzzleId}`;
@@ -837,6 +844,9 @@
             this.solved = initialState.solved || false;
             this.failed = initialState.failed || false;
             this.masked = this.solved || this.failed;
+            this.showResetButtons =
+              !this.endGame && (this.solved || this.failed);
+            this.endGame = false;
             this.currentGuessIndex = initialState.currentGuessIndex || 0;
             this.cursor = initialState.cursor || 0;
             this.cursorMode = initialState.cursorMode || false;
@@ -922,6 +932,7 @@
             guessWords: this.guessWords,
             ...this.guessWordDictionary,
           });
+          this.endGame = true;
           const statistics = this.getFromLocalStorage(
             "statistics",
             DEFAULT_STATISTICS
@@ -941,8 +952,10 @@
         },
         resetLevel() {
           localStorage.removeItem(`game-state-${this.settings.difficulty}`);
-          this.attempt += 1;
           this.loadGameState();
+        },
+        mask() {
+          this.masked = true;
         },
         unmask() {
           this.masked = false;

--- a/index.html
+++ b/index.html
@@ -236,11 +236,11 @@
           <p x-text="target"></p>
         </div>
         <div x-cloak x-show="showResetButtons" class="masked-game-buttons">
-          <button aria-label="Reveal" @click="unmask" x-show="masked">
-            Reveal <i class="material-icons">visibility</i>
+          <button @click="unmask" x-show="masked">
+            Reveal <i class="material-icons" aria-hidden="true">visibility</i>
           </button>
-          <button aria-label="Hide" @click="mask" x-show="!masked">
-            Hide <i class="material-icons">visibility_off</i>
+          <button @click="mask" x-show="!masked">
+            Hide <i class="material-icons" aria-hidden="true">visibility_off</i>
           </button>
           <button aria-label="Reset" @click="resetLevel">
             Reset <i class="material-icons">replay</i>

--- a/index.html
+++ b/index.html
@@ -236,14 +236,11 @@
           <p x-text="target"></p>
         </div>
         <div x-cloak x-show="showResetButtons" class="masked-game-buttons">
-          <button @click="unmask" x-show="masked">
-            Reveal <i class="material-icons" aria-hidden="true">visibility</i>
+          <button @click="masked ? unmask : mask">
+            <span x-text="masked ? 'Reveal' : 'Hide'"></span> <i class="material-icons" aria-hidden="true" x-text="masked ? 'visibility' : 'visibility_off'"></i>
           </button>
-          <button @click="mask" x-show="!masked">
-            Hide <i class="material-icons" aria-hidden="true">visibility_off</i>
-          </button>
-          <button aria-label="Reset" @click="resetLevel">
-            Reset <i class="material-icons">replay</i>
+          <button @click="resetLevel">
+            Reset <i class="material-icons" aria-hidden="true">replay</i>
           </button>
         </div>
         <div class="keyboard">

--- a/index.html
+++ b/index.html
@@ -237,7 +237,12 @@
         </div>
         <div x-cloak x-show="showResetButtons" class="masked-game-buttons">
           <button @click="masked ? unmask : mask">
-            <span x-text="masked ? 'Reveal' : 'Hide'"></span> <i class="material-icons" aria-hidden="true" x-text="masked ? 'visibility' : 'visibility_off'"></i>
+            <span x-text="masked ? 'Reveal' : 'Hide'"></span>
+            <i
+              class="material-icons"
+              aria-hidden="true"
+              x-text="masked ? 'visibility' : 'visibility_off'"
+            ></i>
           </button>
           <button @click="resetLevel">
             Reset <i class="material-icons" aria-hidden="true">replay</i>

--- a/index.html
+++ b/index.html
@@ -235,13 +235,13 @@
           Nice try! It was:
           <p x-text="target"></p>
         </div>
-        <div x-cloak x-show="masked" class="">
-          <div @click="resetLevel">
-            <span>Reset</span><i class="material-icons">replay</i>
-          </div>
-          <div @click="unmask">
-            <span>Reveal</span><i class="material-icons">visibility</i>
-          </div>
+        <div x-cloak x-show="masked" class="masked-game-buttons">
+          <button @click="unmask">
+            Reveal <i class="material-icons">visibility</i>
+          </button>
+          <button @click="resetLevel">
+            Reset <i class="material-icons">replay</i>
+          </button>
         </div>
         <div class="keyboard">
           <template x-if="!solved && !failed">

--- a/public/main.css
+++ b/public/main.css
@@ -427,14 +427,28 @@ main {
 
 .masked-game-buttons button {
   cursor: pointer;
-  background-color: var(--color-neutral-20);
+  background-color: var(--color-neutral-10);
   color: var(--color-neutral-100);
-  width: 100px;
-  border-radius: 5px;
+  border-radius: 4px;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 4px 6px 4px 12px;
+  font-size: 14px;
+}
+
+.masked-game-buttons .material-icons {
+  font-size: inherit;
 }
 
 .masked-game-buttons button:hover {
-  background-color: var(--color-neutral-10);
+  filter: brightness(1.5);
+}
+
+.masked-game-buttons button:focus-visible {
+  outline: 2px solid white;
 }
 
 .unavailable {

--- a/public/main.css
+++ b/public/main.css
@@ -427,8 +427,14 @@ main {
 
 .masked-game-buttons button {
   cursor: pointer;
-  background-color: var(--color-notice-bg);
-  color: var(--color-notice-text);
+  background-color: var(--color-neutral-20);
+  color: var(--color-neutral-100);
+  width: 100px;
+  border-radius: 5px;
+}
+
+.masked-game-buttons button:hover {
+  background-color: var(--color-neutral-10);
 }
 
 .unavailable {

--- a/public/main.css
+++ b/public/main.css
@@ -418,6 +418,19 @@ main {
   font-size: 2rem;
 }
 
+.masked-game-buttons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+}
+
+.masked-game-buttons button {
+  cursor: pointer;
+  background-color: var(--color-notice-bg);
+  color: var(--color-notice-text);
+}
+
 .unavailable {
   background-color: var(--color-miss);
   cursor: auto;


### PR DESCRIPTION
When going back to view an already completed puzzle, it will show a pair of buttons instead of the "You win" text.

Reveal  / Reset

<img width="382" alt="Screen Shot 2022-02-22 at 9 09 12 AM" src="https://user-images.githubusercontent.com/513961/155182974-c2a89ee8-4349-4f67-ad70-5714966af1d5.png">

<img width="384" alt="Screen Shot 2022-02-22 at 9 09 22 AM" src="https://user-images.githubusercontent.com/513961/155182966-2f8b786b-311c-4412-b40a-6d36c32ed438.png">

Resolves #34 

The changes to the `:key` are necessary to ensure it redraws properly after a level reset.