### PR TITLE
Use twemoji instead of raw characters

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,34 +307,6 @@
               </div>
             </template>
           </div>
-
-          <!-- testing purposes only -->
-          <template x-for="(emoji, i) in emojis">
-            <div class="guesses-word" :class="settings.case">
-              <!-- original character -->
-              <div class="guesses-tile emoji-tile">
-                <span x-text="emoji"></span>
-              </div>
-              <!-- on default background -->
-              <div class="guesses-tile emoji-tile">
-                <img :src="getEmojiImage(emoji)" width="32" />
-              </div>
-              <!-- on default background, dark drop-shadow to compensate for poor contrast for blue/grey emojis -->
-              <div class="guesses-tile preview-light">
-                <img :src="getEmojiImage(emoji)" width="32" />
-              </div>
-              <!-- on dark background (like notice), white drop-shadow to compensate for dark emojis -->
-              <div class="guesses-tile preview-dark">
-                <img :src="getEmojiImage(emoji)" width="32" />
-              </div>
-              <template x-for="letter in i">
-                <div class="guesses-tile match">
-                  <span x-text="letter"></span>
-                </div>
-              </template>
-            </div>
-          </template>
-
           <template x-for="(collectable, i) in unlockedEmojis">
             <div
               class="guesses-word"
@@ -342,7 +314,11 @@
               :class="settings.case"
             >
               <div class="guesses-tile emoji-tile">
-                <span x-text="collectable.emoji"></span>
+                <img
+                  :src="getEmojiImage(collectable.emoji)"
+                  class="emoji-image"
+                  width="32"
+                />
               </div>
               <template x-for="letter in collectable.word">
                 <div class="guesses-tile match">

--- a/index.html
+++ b/index.html
@@ -1079,6 +1079,8 @@
         notify(notice) {
           notice.id = Date.now();
           notice.visible = true;
+          // TODO: allow HTML for emoji unlock notices
+          // <img :src="getEmojiImage(emoji)" width="32" />
           this.notice = notice;
           const timeShown = 5 * 1000;
           setTimeout(() => {

--- a/index.html
+++ b/index.html
@@ -307,6 +307,34 @@
               </div>
             </template>
           </div>
+
+          <!-- testing purposes only -->
+          <template x-for="(emoji, i) in emojis">
+            <div class="guesses-word" :class="settings.case">
+              <!-- original character -->
+              <div class="guesses-tile emoji-tile">
+                <span x-text="emoji"></span>
+              </div>
+              <!-- on default background -->
+              <div class="guesses-tile emoji-tile">
+                <img :src="getEmojiImage(emoji)" width="32" />
+              </div>
+              <!-- on default background, dark drop-shadow to compensate for poor contrast for blue/grey emojis -->
+              <div class="guesses-tile preview-light">
+                <img :src="getEmojiImage(emoji)" width="32" />
+              </div>
+              <!-- on dark background (like notice), white drop-shadow to compensate for dark emojis -->
+              <div class="guesses-tile preview-dark">
+                <img :src="getEmojiImage(emoji)" width="32" />
+              </div>
+              <template x-for="letter in i">
+                <div class="guesses-tile match">
+                  <span x-text="letter"></span>
+                </div>
+              </template>
+            </div>
+          </template>
+
           <template x-for="(collectable, i) in unlockedEmojis">
             <div
               class="guesses-word"

--- a/index.html
+++ b/index.html
@@ -449,7 +449,7 @@
         x-cloak
         x-show="notice?.visible"
         @click="remove(notice?.id)"
-        x-text="notice?.text"
+        x-html="message"
         x-transition:enter="fadein"
       ></div>
     </main>
@@ -1055,8 +1055,6 @@
         notify(notice) {
           notice.id = Date.now();
           notice.visible = true;
-          // TODO: allow HTML for emoji unlock notices
-          // <img :src="getEmojiImage(emoji)" width="32" />
           this.notice = notice;
           const timeShown = 5 * 1000;
           setTimeout(() => {
@@ -1066,6 +1064,20 @@
         remove(id) {
           if (this.notice.id === id) {
             this.notice.visible = false;
+          }
+        },
+        message() {
+          if (!this.notice) return;
+          const stripped = this.notice.text.replace(/(<([^>]+)>)/gi, "");
+
+          const emojis = stripped.match(/[\p{Emoji}\u200d\ufe0f]+/gu);
+          if (!emojis) {
+            return stripped;
+          } else {
+            const emojiImage = `<img src="${getEmojiImage(
+              emojis.join("")
+            )}" class="emoji-image" width="20" />`;
+            return stripped.replace(emojis, emojiImage);
           }
         },
       };

--- a/index.html
+++ b/index.html
@@ -622,7 +622,7 @@
             (entry) => entry.word === this.currentWord
           );
           if (emoji && !alreadyFound) {
-            this.showNotice(`You unlocked ${emoji} !`);
+            this.showNotice(`You unlocked #${emoji}# !`);
           }
         },
         updateKeyboardForGuess(guess) {
@@ -1070,14 +1070,18 @@
           if (!this.notice) return;
           const stripped = this.notice.text.replace(/(<([^>]+)>)/gi, "");
 
-          const emojis = stripped.match(/[\p{Emoji}\u200d\ufe0f]+/gu);
-          if (!emojis) {
+          // extract emoji between # characters
+          // (actually detecting with regex has too many edge cases)
+          const emojiMatch = stripped.match(/#(?<emoji>\S+)#/i);
+          if (!emojiMatch) {
             return stripped;
           } else {
             const emojiImage = `<img src="${getEmojiImage(
-              emojis.join("")
+              emojiMatch.groups.emoji
             )}" class="emoji-image" width="20" />`;
-            return stripped.replace(emojis, emojiImage);
+            return stripped
+              .replace(/#/g, "")
+              .replace(emojiMatch.groups.emoji, emojiImage);
           }
         },
       };

--- a/public/emojis.js
+++ b/public/emojis.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const emojis = {
   ABACUS: "🧮",
   ABCD: "🔠",
@@ -319,7 +321,7 @@ const emojis = {
   MOUSE: "🐭",
   MOUTH: "👄",
   MOVIE: "🎥",
-  MUSIC: "🎵",
+  MUSIC: "🎶",
   NAIL: "💅",
   NEEDLE: "💉",
   NERD: "🤓",
@@ -328,7 +330,7 @@ const emojis = {
   NINE: "9️⃣",
   NINJA: "🥷",
   NOSE: "👃",
-  NOTE: "♫",
+  NOTE: "🎵",
   NURSE: "🤱",
   ODEN: "🍢",
   OGRE: "👹",
@@ -588,6 +590,36 @@ const emojis = {
   ZOMBIE: "🧟",
 };
 
+/**
+ * @param {string} input
+ */
+function getUnicodeCodePoint(input) {
+  const result = [];
+  for (let codePoint of input) {
+    result.push(codePoint.codePointAt(0).toString(16));
+  }
+  return result.join("-");
+}
+
+const variantCharacter = /\uFE0F/g;
+const zeroWidthJoiner = "\u200D";
+
+/**
+ * Remove the possible variant and convert utf16 into code points.
+ * If there is a zero-width-joiner (U+200D), leave the variants in.
+ *
+ * @param {string} emoji - actual character, eg 😂
+ */
+function getEmojiImage(emoji) {
+  const normalized =
+    emoji.indexOf(zeroWidthJoiner) < 0
+      ? emoji.replace(variantCharacter, "")
+      : emoji;
+  const codePoint = getUnicodeCodePoint(normalized);
+  // or png: https://twemoji.maxcdn.com/v/13.1.0/72x72/1f004.png
+  return `https://twemoji.maxcdn.com/v/13.1.0/svg/${codePoint}.svg`;
+}
+
 if (typeof module !== "undefined") {
-  module.exports = { emojis };
+  module.exports = { emojis, getEmojiImage };
 }

--- a/public/main.css
+++ b/public/main.css
@@ -116,7 +116,6 @@ header nav {
   justify-content: center;
 }
 .nav-tabs .status {
-  /* filter: grayscale(1); */
   font: inherit;
   padding: 0 4px 0 0;
   font-size: 0.8rem;
@@ -387,6 +386,10 @@ main {
 
 .emoji-image {
   filter: drop-shadow(0px 0px 1px var(--emoji-outline, var(--color-nav)));
+}
+
+.notice .emoji-image {
+  filter: drop-shadow(0px 0px 0px #fff);
 }
 
 .cursor {

--- a/public/main.css
+++ b/public/main.css
@@ -379,6 +379,24 @@ main {
   border: none;
   background: none;
 }
+.preview-light {
+  border: none;
+  background: none;
+  --preview-outline: #00000099;
+}
+.preview-dark {
+  border-radius: unset;
+  background-color: var(--color-notice-bg);
+  --preview-outline: #ffffffee;
+}
+.preview-light img,
+.preview-dark img {
+  filter: drop-shadow(0px 0px 1px var(--preview-outline));
+  /* filter: drop-shadow(1px 1px 0 var(--preview-outline))
+    drop-shadow(-1px 1px 0 var(--preview-outline))
+    drop-shadow(1px -1px 0 var(--preview-outline))
+    drop-shadow(-1px -1px 0 var(--preview-outline)); */
+}
 
 .cursor {
   box-shadow: 0 0 0px 1px rgba(0, 0, 0, 30), rgba(0, 0, 0, 30) 3px 3px;

--- a/public/main.css
+++ b/public/main.css
@@ -42,6 +42,11 @@ body {
   box-sizing: border-box;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 body {
   margin: 0;
   padding: 0;
@@ -379,23 +384,9 @@ main {
   border: none;
   background: none;
 }
-.preview-light {
-  border: none;
-  background: none;
-  --preview-outline: #00000099;
-}
-.preview-dark {
-  border-radius: unset;
-  background-color: var(--color-notice-bg);
-  --preview-outline: #ffffffee;
-}
-.preview-light img,
-.preview-dark img {
-  filter: drop-shadow(0px 0px 1px var(--preview-outline));
-  /* filter: drop-shadow(1px 1px 0 var(--preview-outline))
-    drop-shadow(-1px 1px 0 var(--preview-outline))
-    drop-shadow(1px -1px 0 var(--preview-outline))
-    drop-shadow(-1px -1px 0 var(--preview-outline)); */
+
+.emoji-image {
+  filter: drop-shadow(0px 0px 1px var(--emoji-outline, var(--color-nav)));
 }
 
 .cursor {

--- a/test/emojis.test.js
+++ b/test/emojis.test.js
@@ -1,5 +1,5 @@
 const fs = require("fs");
-const { emojis } = require("../public/emojis");
+const { emojis, getEmojiImage } = require("../public/emojis");
 
 describe("emojis", () => {
   it("uppercase keys", () => {
@@ -39,5 +39,24 @@ describe("emojis", () => {
       }
       return memo;
     }, {});
+  });
+});
+
+describe("getEmojiImage", () => {
+  it("unicode 13 character", () => {
+    const src = getEmojiImage("🪰");
+    expect(src).toBe(`https://twemoji.maxcdn.com/v/13.1.0/svg/1fab0.svg`);
+  });
+  it("variants", () => {
+    const src = getEmojiImage("👩‍⚕️");
+    expect(src).toBe(
+      `https://twemoji.maxcdn.com/v/13.1.0/svg/1f469-200d-2695-fe0f.svg`
+    );
+  });
+  it("trailing zero width joiner", () => {
+    const src1 = getEmojiImage("⭐️");
+    const src2 = getEmojiImage("\u2B50\uFE0F");
+    expect(src1).toBe(`https://twemoji.maxcdn.com/v/13.1.0/svg/2b50.svg`);
+    expect(src2).toEqual(src1);
   });
 });

--- a/test/emojis.test.js
+++ b/test/emojis.test.js
@@ -19,7 +19,7 @@ describe("emojis", () => {
     // read file as string to avoid treating as JS
     // (object keys silently overwrite one another)
     const input = fs.readFileSync("./public/emojis.js", "utf8");
-    const matches = input.matchAll(/\s*([A-Z]+)/g);
+    const matches = input.matchAll(/^\s\s([A-Z]+)/g);
     const keys = Array.from(matches).map((result) => result[1]);
     if (keys.length != new Set(keys).size) {
       Object.values(keys).reduce((memo, key) => {


### PR DESCRIPTION
preview of what it would look like

columns:
- existing emoji character (status quo)
- twemoji image
- twemoji image with dark drop-shadow (to fix blue/grey ones)
- twemoji image with dark bg and light drop-shadow (to fix dark ones in notice message)

<img width="442" alt="image" src="https://user-images.githubusercontent.com/438545/155086893-71b289ca-599d-43d1-a3c4-8d874355f210.png">

Closes #37 (though we may decide later to pay for JoyPixels)
