### PR TITLE
add CSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,19 @@
       name="description"
       content="A kid-friendly version of the popular Wordle game"
     />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
+        default-src 'self';
+        script-src 'self' https://cdn.amplitude.com https://unpkg.com/alpinejs 'unsafe-eval' 'unsafe-inline'; 
+        style-src 'self' https://fonts.googleapis.com; 
+        font-src 'self' https://fonts.gstatic.com; 
+        img-src 'self' https://twemoji.maxcdn.com;
+        connect-src 'self' https://api.amplitude.com;
+        object-src 'none';
+        manifest-src 'self';
+        "
+    />
 
     <meta property="og:url" content="https://spelliegame.com" />
     <meta property="og:type" content="website" />
@@ -25,8 +38,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
     <link rel="manifest" href="site.webmanifest" />
-
-    <script src="//unpkg.com/alpinejs" defer></script>
+    <script src="https://unpkg.com/alpinejs" defer></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
Spellie is basically all static, so it's already quite safe. Wordle has one, though - probably since the NYT switch (it's an HTTP header on the main doc).

Alpine requires some unsafe inline JS, but having this in place is better than nothing.
I've tested it locally but after merging we should check prod just in case.