### PR TITLE
Scale font size of tile grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -494,6 +494,7 @@
   <script>
     const puzzleId = getTodayPuzzleId();
     const maxGuesses = 6;
+    initScalingFontSize();
 
     // Add emoji keys to valid words
     // So that ELSA and ROFL are accepted
@@ -1165,6 +1166,49 @@
           }
         },
       };
+    }
+
+    function initScalingFontSize() {
+      if ("ResizeObserver" in window === false) {
+        amplitude.getInstance().logEvent("error_encountered", {
+          message: "ResizeObserver not supported",
+        });
+        return;
+      }
+
+      const MAX_FONT_SIZE = 48;
+      const grid = document.querySelector(".guesses-grid");
+
+      /** Set grid font, which in turn impacts all guess tiles */
+      function setGridFontSize(container) {
+        if (!container.offsetWidth) return;
+
+        let tileWidth;
+        const sampleTile = container.querySelector(".guesses-tile");
+        if (sampleTile && sampleTile.offsetWidth) {
+          // found a tile, so base it on the tile dimensions
+          tileWidth = sampleTile.offsetWidth;
+        } else if (container.offsetHeight < container.offsetWidth) {
+          // no tile (probably not yet rendered), so estimate it based on container
+          tileWidth = container.offsetHeight / 6;
+        } else {
+          tileWidth = container.offsetWidth / 6;
+        }
+
+        const fontSize = 0.7 * tileWidth;
+        // console.log("setting font size", fontSize, tileWidth);
+        grid.style.fontSize = Math.min(MAX_FONT_SIZE, fontSize) + "px";
+      }
+
+      const resizeObserver = new ResizeObserver((entries) => {
+        for (let entry of entries) {
+          if (entry.target) {
+            setGridFontSize(entry.target);
+          }
+        }
+      });
+
+      resizeObserver.observe(grid);
     }
 
     window.onerror = function (message, url, lineNo, columnNo, error) {

--- a/public/main.css
+++ b/public/main.css
@@ -250,6 +250,7 @@ main {
     min-height: 280px;
   }
   .guesses-row {
+    min-height: 32px;
     align-items: initial;
   }
   .guesses-tile {

--- a/public/main.css
+++ b/public/main.css
@@ -193,6 +193,7 @@ main {
 .guesses-grid {
   min-height: 0;
   padding: 8px;
+  font-size: 1rem;
 }
 
 .target-4 {
@@ -237,26 +238,10 @@ main {
   aspect-ratio: 1/1;
   border: 2px solid var(--color-border);
   border-radius: 50%;
-  font-size: 0.5rem;
+  font-size: 1em; /* inherit from font-size of .guesses-grid, set via JS */
   line-height: 1;
   background: var(--color-empty);
   transition: background linear 0.5s;
-}
-
-@media screen and (min-height: 565px) {
-  .guesses-tile {
-    font-size: 1rem;
-  }
-}
-@media screen and (min-height: 650px) {
-  .guesses-tile {
-    font-size: 1.5rem;
-  }
-}
-@media screen and (min-height: 750px) {
-  .guesses-tile {
-    font-size: 2rem;
-  }
 }
 
 /* use fixed sizes for legacy safari */
@@ -493,7 +478,7 @@ main {
   width: 40px;
   height: 40px;
   padding: 0;
-  /* font-size: 1.5rem; */
+  font-size: 1.5rem;
 }
 
 .heavy-letter {

--- a/public/main.css
+++ b/public/main.css
@@ -235,6 +235,7 @@ main {
   display: flex;
   justify-content: center;
   align-items: center;
+  height: 100%;
   aspect-ratio: 1/1;
   border: 2px solid var(--color-border);
   border-radius: 50%;


### PR DESCRIPTION
This approach works pretty well - better than picking media breakpoints, and more reliable than resize events. Previously, the height breakpoint was causing small fonts on some mobile devices.

Try it out and let me know what you think.

Closes #36
Closes #87