### PR TITLE
Add notifications for new emojis

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,12 @@
             <i class="material-icons">share</i>
           </a>
           <a href="#collection" class="nav-link">
+            <span
+              class="nav-notification"
+              x-cloak
+              x-show="sessionNewEmojis.length > 0"
+              x-text="sessionNewEmojis.length"
+            ></span>
             <i class="material-icons">collections</i>
           </a>
           <a href="#settings" class="nav-link">
@@ -307,7 +313,7 @@
             <div
               class="guesses-word"
               x-show="collectable.unlocked"
-              :class="settings.case"
+              :class="[settings.case, collectable.new ? 'pulse' : '']"
             >
               <div class="guesses-tile emoji-tile">
                 <img
@@ -641,7 +647,6 @@
           });
           this.updateKeyboardForGuess(this.currentWord);
           this.checkEmojiGuess();
-          this.addToCollection(this.currentWord);
           this.solved = this.currentWord === this.target;
           this.currentGuessIndex += 1;
           if (this.solved) {
@@ -665,6 +670,18 @@
           if (emoji && !alreadyFound) {
             this.showNotice(`You unlocked #${emoji}# !`);
             this.newEmojis.push(emoji);
+            const collection = this.getFromLocalStorage("collection", {
+              unlocked: {},
+            });
+            collection.unlocked[this.currentWord] = {
+              date: new Date().toISOString(),
+            };
+            localStorage.setItem("collection", JSON.stringify(collection));
+            const collectable = this.emojiCollection.find(
+              (collectable) => collectable.word === this.currentWord
+            );
+            collectable.unlocked = true;
+            collectable.new = true;
           }
         },
         updateKeyboardForGuess(guess) {
@@ -971,19 +988,6 @@
               };
             });
         },
-        addToCollection(newWord) {
-          if (emojis[newWord]) {
-            const collection = this.getFromLocalStorage("collection", {
-              unlocked: {},
-            });
-            collection.unlocked[newWord] = { date: new Date().toISOString() };
-            localStorage.setItem("collection", JSON.stringify(collection));
-            const collectable = this.emojiCollection.find(
-              (collectable) => collectable.word === newWord
-            );
-            collectable.unlocked = true;
-          }
-        },
         levelEnd() {
           amplitude.getInstance().logEvent("level_end", {
             level_name: this.level,
@@ -1013,6 +1017,9 @@
         },
         get unlockedEmojis() {
           return this.emojiCollection.filter((e) => e.unlocked);
+        },
+        get sessionNewEmojis() {
+          return this.unlockedEmojis.filter((e) => e.new);
         },
         resetLevel() {
           localStorage.removeItem(`game-state-${this.settings.difficulty}`);

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
             <div
               class="guesses-word"
               x-show="collectable.unlocked"
-              :class="[settings.case, collectable.new ? 'pulse' : '']"
+              :class="[settings.case]"
             >
               <div class="guesses-tile emoji-tile">
                 <img
@@ -326,7 +326,10 @@
                 />
               </div>
               <template x-for="letter in collectable.word">
-                <div class="guesses-tile match">
+                <div
+                  class="guesses-tile"
+                  :class="collectable.new ? 'present' : 'match'"
+                >
                   <span x-text="letter"></span>
                 </div>
               </template>

--- a/index.html
+++ b/index.html
@@ -320,6 +320,7 @@
                   :src="getEmojiImage(collectable.emoji)"
                   :onerror="`this.onerror=null;this.replaceWith('${collectable.emoji}')`"
                   class="emoji-image"
+                  :class="collectable.new ? 'pulse' : ''"
                   width="32"
                   height="32"
                   :alt="collectable.word"

--- a/public/main.css
+++ b/public/main.css
@@ -111,9 +111,9 @@ header nav {
 }
 
 .nav-notification {
-  background-color: red;
+  background-color: var(--color-present);
   border-radius: 50%;
-  color: var(--color-title);
+  color: var(--color-text);
 
   padding: 0px 3px;
   font-size: 10px;

--- a/public/main.css
+++ b/public/main.css
@@ -105,8 +105,22 @@ header nav {
 
 .nav-link {
   display: inline-block;
+  position: relative;
   color: var(--color-bg);
   cursor: pointer;
+}
+
+.nav-notification {
+  background-color: red;
+  border-radius: 50%;
+  color: var(--color-title);
+
+  padding: 0px 3px;
+  font-size: 10px;
+
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
 .nav-tabs {


### PR DESCRIPTION
A little bit of visual flair for newly unlocked emojis.

Would like feedback on the styling.
<img width="497" alt="Screen Shot 2022-03-03 at 7 04 41 PM" src="https://user-images.githubusercontent.com/513961/156691760-f1a687c9-7bca-4ed6-9ef8-d998a3a99e19.png">
<img width="561" alt="Screen Shot 2022-03-03 at 7 05 23 PM" src="https://user-images.githubusercontent.com/513961/156691763-36020b39-8e76-4e4b-a8d3-de63345526bd.png">
<img width="642" alt="Screen Shot 2022-03-03 at 7 06 13 PM" src="https://user-images.githubusercontent.com/513961/156691767-7c51087e-113e-4f7b-ac29-ae681e5a5b72.png">
<img width="537" alt="Screen Shot 2022-03-03 at 7 06 20 PM" src="https://user-images.githubusercontent.com/513961/156691768-daf03d61-64aa-4bb1-a4db-9d33a308b5c9.png">


I had it red originally but went with a consistent colour from our existing pallet. 
(with red)
![Screen Shot 2022-03-03 at 4 58 01 PM](https://user-images.githubusercontent.com/513961/156678806-b6b6094e-6b6f-4f3c-98da-0aac1f8e942a.png)
