### PR TITLE
End of game buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,6 +247,9 @@
           <button @click="resetLevel">
             Reset <i class="material-icons" aria-hidden="true">replay</i>
           </button>
+          <button @click="share" x-show="canShare">
+            Share <i class="material-icons" aria-hidden="true">share</i>
+          </button>
         </div>
         <div class="keyboard">
           <template x-if="!solved && !failed">

--- a/public/main.css
+++ b/public/main.css
@@ -433,16 +433,17 @@ main {
 
 .masked-game-buttons button {
   cursor: pointer;
-  background-color: var(--color-neutral-10);
-  color: var(--color-neutral-100);
-  border-radius: 4px;
-  border: none;
-  display: flex;
+  background-color: var(--color-empty);
+  color: var(--color-text);
+  border-radius: 15px;
+  border: 2px solid var(--color-border);
+  box-shadow: rgb(0 0 0) 2px 2px;
   align-items: center;
   justify-content: center;
   gap: 4px;
-  padding: 4px 6px 4px 12px;
-  font-size: 14px;
+  padding: 4px;
+  font-size: 1rem;
+  width: 70px;
 }
 
 .masked-game-buttons .material-icons {
@@ -450,11 +451,7 @@ main {
 }
 
 .masked-game-buttons button:hover {
-  filter: brightness(1.5);
-}
-
-.masked-game-buttons button:focus-visible {
-  outline: 2px solid white;
+  outline: 2px solid var(--color-neutral-100);
 }
 
 .unavailable {


### PR DESCRIPTION
Make end of game buttons look like available keys
Add a Share button
Give buttons a consistent width so reveal/hide doesn't cause button width to change when text does
Make the width narrower so that icon is on the 2nd line - small enough for mobile.

![Screen Shot 2022-03-08 at 9 04 01 PM](https://user-images.githubusercontent.com/513961/157376741-262b0915-ce41-4ba7-8a14-541324092620.png)


Resolves #103 
Resolves #109 