### PR TITLE
Ensure cursor mode is disabled by on screen keyboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -652,6 +652,7 @@
             }
             this.updateControls();
             this.saveGameState();
+            this.cursorMode = false;
           } else if (letterState.type === "back") {
             const deleteIndex = this.cursorMode ? this.cursor : this.cursor - 1;
             if (
@@ -672,6 +673,7 @@
               this.currentGuess[this.cursor].letter =
                 letterState.label.toUpperCase();
               this.cursor += 1;
+              this.cursorMode = false;
               this.updateControls();
             }
           }
@@ -786,7 +788,6 @@
           if (e.key === "Enter" || e.key === " ") {
             e.target.blur();
             this.addLetter({ type: "enter" });
-            this.cursorMode = false;
           } else if (e.key === "Backspace") {
             e.target.blur();
             this.addLetter({ type: "back" });
@@ -808,7 +809,6 @@
           ) {
             e.target.blur(); // user is no longer navigating by tab
             this.addLetter({ type: "letter", label: e.key });
-            this.cursorMode = false;
           }
         },
         selectTile(guessIndex, letterIndex) {


### PR DESCRIPTION
Ensure the logic for onscreen keyboard and physical keyboard stays the same.

Fix bug where entering the last letter using on screen keyboard doesn't disable cursorMode so backspace doesn't work properly

To reproduce:
1. click on the last bubble of a word
2. enter a letter using the onscreen keyboard.
3. try deleting that letter with the backpsace key (physical or on-screen)