### PR TITLE
Balance icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
   <body
     x-data="gameState()"
     x-init="initialLoad()"
-    :class="`theme-${settings.theme}`"
+    :class="`theme-${settings.theme} page-${page.replace('#', '')}`"
     @keyup.document="keyPressed"
     @hashchange.window="updatePage(location.hash)"
   >
@@ -345,7 +345,7 @@
           <span
             x-text="Math.floor(Object.keys(emojis).length / 100)  * 100"
           ></span>
-          in total...
+          emojis in total...
         </p>
       </div>
       <div class="settings-content" x-show="page === '#settings'" x-cloak>

--- a/index.html
+++ b/index.html
@@ -51,17 +51,6 @@
     <header>
       <nav>
         <div>
-          <a
-            x-bind:href="`#${difficulty}`"
-            class="nav-link"
-            x-show="!isGamePage()"
-            x-cloak
-          >
-            <i class="material-icons">arrow_back</i>
-          </a>
-        </div>
-        <div class="title">Spellie</div>
-        <div>
           <a href="#about" class="nav-link">
             <i class="material-icons">info</i>
           </a>
@@ -74,6 +63,9 @@
           >
             <i class="material-icons">share</i>
           </a>
+        </div>
+        <div class="title">Spellie</div>
+        <div>
           <a href="#collection" class="nav-link">
             <span
               class="nav-notification"
@@ -111,7 +103,14 @@
     </header>
     <main :class="`target-${target.length}`">
       <div class="about-content" x-show="page === '#about'" x-cloak>
-        <h1>About</h1>
+        <div class="subhead">
+          <h1>About</h1>
+          <div>
+            <a x-bind:href="`#${difficulty}`">
+              <i class="material-icons">close</i>
+            </a>
+          </div>
+        </div>
         <p>Spellie is a daily word puzzle game for young spellers.</p>
         <p>
           There are 3 daily puzzles of increasing difficulty. The easy puzzle
@@ -173,10 +172,10 @@
         </ul>
         <div class="social-links">
           <a href="https://twitter.com/SpellieGame" target="_blank"
-            ><img src="public/twitter.png"
+            ><img src="public/twitter.png" alt="Twitter"
           /></a>
           <a href="https://github.com/canadianveggie/spellie" target="_blank"
-            ><img src="public/github.png"
+            ><img src="public/github.png" alt="GitHub"
           /></a>
         </div>
       </div>
@@ -283,7 +282,15 @@
         </div>
       </div>
       <div class="collection-content" x-show="page === '#collection'" x-cloak>
-        <h1>Collection</h1>
+        <div class="subhead">
+          <h1>Collection</h1>
+          <div>
+            <a x-bind:href="`#${difficulty}`" class="close-link">
+              <i class="material-icons">close</i>
+            </a>
+          </div>
+        </div>
+
         <p x-show="unlockedEmojis.length === 0">
           Your word guesses can unlock hidden emojis.<br />Maybe you'll find one
           next game.
@@ -349,7 +356,14 @@
         </p>
       </div>
       <div class="settings-content" x-show="page === '#settings'" x-cloak>
-        <h1>Settings</h1>
+        <div class="subhead">
+          <h1>Settings</h1>
+          <div>
+            <a x-bind:href="`#${difficulty}`" class="close-link">
+              <i class="material-icons">close</i>
+            </a>
+          </div>
+        </div>
         <section>
           <h2>Keyboard layout</h2>
           <div>

--- a/public/main.css
+++ b/public/main.css
@@ -14,7 +14,6 @@
   --color-nav: #004b84;
   --color-bg: var(--color-nav); /* match nav until theme loaded */
   --color-page-bg: var(--color-nav); /* match nav until theme loaded */
-  --color-border-header: #818384;
   --color-border: var(--color-neutral-10);
 
   --color-available: #fff;

--- a/public/main.css
+++ b/public/main.css
@@ -13,6 +13,7 @@
   --color-title: #fff;
   --color-nav: #004b84;
   --color-bg: var(--color-nav); /* match nav until theme loaded */
+  --color-page-bg: var(--color-nav); /* match nav until theme loaded */
   --color-border-header: #818384;
   --color-border: var(--color-neutral-10);
 
@@ -57,14 +58,22 @@ body {
   transition: background 0.2s;
 }
 
+body.page-about,
+body.page-collection,
+body.page-settings {
+  background: var(--color-page-bg);
+}
+
 .theme-blue {
   --color-bg: #30a3fc;
+  --color-page-bg: #f0f1f3;
   --color-miss: transparent;
   --color-present: #ffcb22;
   --color-match: #9fef00;
 }
 .theme-high {
   --color-bg: #f0f1f3;
+  --color-page-bg: var(--color-bg);
   --color-miss: #e3e4e8;
   --color-present: #86c0f9;
   --color-match: #f5793a;

--- a/public/main.css
+++ b/public/main.css
@@ -55,7 +55,6 @@ body {
   font-family: "Comic Neue", sans-serif;
   background: var(--color-bg);
   color: var(--color-text);
-  transition: background 0.2s;
 }
 
 body.page-about,
@@ -206,6 +205,7 @@ main {
   justify-content: space-between;
 }
 
+.close-link,
 .close-link:active {
   color: inherit;
 }

--- a/public/main.css
+++ b/public/main.css
@@ -111,6 +111,7 @@ header nav {
   right: 0;
   top: 35%;
   transform: translateY(-50%);
+  padding: 1rem;
 }
 
 .nav-link {
@@ -198,6 +199,15 @@ main {
   main {
     padding: 1rem;
   }
+}
+
+.subhead {
+  display: flex;
+  justify-content: space-between;
+}
+
+.close-link:active {
+  color: inherit;
 }
 
 .lowercase {
@@ -514,6 +524,7 @@ main {
 }
 
 .social-links {
+  margin-top: 2rem;
   display: flex;
   justify-content: center;
   gap: 16px;

--- a/public/puzzles.js
+++ b/public/puzzles.js
@@ -877,7 +877,7 @@ const wordsHard = [
   "VEhST05F",
   "U1BFRURZ",
   "U0xJR0hU",
-  "VVNVQUw=",
+  "UE9SVEVS",
   "R1JBU1M=",
   "VFJJRUQ=",
   "Q0FOQUw=",


### PR DESCRIPTION
On small devices, the icons could overlap the title.

Also change the bg color because it was bugging me. I think white makes the most senses on sub-pages, where there's lots of text to read.

<table>
<td>
<img width="507" alt="image" src="https://user-images.githubusercontent.com/438545/159147047-69ac3c1e-6738-4578-b051-9697cade163a.png">
</td>
<td>

<img width="472" alt="image" src="https://user-images.githubusercontent.com/438545/159147052-f3686483-ca4d-4e95-9b30-10d4047e6d32.png">
</td>
</table>

<table>
<td>
<img width="341" alt="image" src="https://user-images.githubusercontent.com/438545/159147344-e5c5a31f-8172-4b5f-ac2e-eba85b743a76.png">
</td>
<td>
<img width="341" alt="image" src="https://user-images.githubusercontent.com/438545/159147368-b2d0953f-6bc5-410f-9365-565988032be7.png">
</td>
</table


