### PR TITLE
Strict types

### DIFF
--- a/index.html
+++ b/index.html
@@ -1084,12 +1084,12 @@
               (this.cursorReverse ? this.target.length - 1 : 0);
             this.cursorMode = initialState.cursorMode || false;
             this.newEmojis = initialState.newEmojis || [];
-            this.hintKnowledge = initialState.hintKnowledge || {
-              matches: [],
-              presents: [],
-              misses: [],
-              availables: [],
-            };
+            this.hintKnowledge = initialState.hintKnowledge || {};
+            // Ensure all the knowledge is present. We used to save it as an empty object
+            this.hintKnowledge.matches = this.hintKnowledge.matches || [];
+            this.hintKnowledge.presents = this.hintKnowledge.presents || [];
+            this.hintKnowledge.misses = this.hintKnowledge.misses || [];
+            this.hintKnowledge.availables = this.hintKnowledge.availables || [];
             this.updateKeyboard();
             this.resetHint();
             clearTimeout(this.endGameTimer);

--- a/index.html
+++ b/index.html
@@ -658,7 +658,12 @@
         keys: initialKeys(),
         emojiCollection: [],
         newEmojis: [],
-        hintKnowledge: {},
+        hintKnowledge: {
+          matches: [],
+          presents: [],
+          misses: [],
+          availables: [],
+        },
         updatePage(page) {
           this.page = page;
           const titles = {
@@ -796,11 +801,11 @@
           });
         },
         updateKeyboardForHints(hintKnowledge) {
-          (hintKnowledge.misses || []).forEach((missLetter) => {
+          hintKnowledge.misses.forEach((missLetter) => {
             const key = this.keys.find((letter) => letter.label === missLetter);
             key.state = "miss";
           });
-          (hintKnowledge.presents || []).forEach((presentLetter) => {
+          hintKnowledge.presents.forEach((presentLetter) => {
             const key = this.keys.find(
               (letter) => letter.label === presentLetter
             );
@@ -1079,7 +1084,12 @@
               (this.cursorReverse ? this.target.length - 1 : 0);
             this.cursorMode = initialState.cursorMode || false;
             this.newEmojis = initialState.newEmojis || [];
-            this.hintKnowledge = initialState.hintKnowledge || {};
+            this.hintKnowledge = initialState.hintKnowledge || {
+              matches: [],
+              presents: [],
+              misses: [],
+              availables: [],
+            };
             this.updateKeyboard();
             this.resetHint();
             clearTimeout(this.endGameTimer);

--- a/public/emojis.js
+++ b/public/emojis.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+/** @type {{[name: string]: string}} */
 const emojis = {
   ABACUS: "🧮",
   ABCD: "🔠",

--- a/public/hint.js
+++ b/public/hint.js
@@ -40,6 +40,7 @@ const LETTERS_BY_FREQUENCY = [
  * @returns {string | null} - the multiple letter
  */
 function findMultiple(letters) {
+  /** @type {{ [letter: string]: boolean; }} */
   const seen = {};
   for (let i = 0; i < letters.length; i++) {
     const letter = letters[i];
@@ -52,6 +53,7 @@ function findMultiple(letters) {
   return null;
 }
 
+/** @type {{ [letter: string]: string; }} */
 const hintLetterMap = {
   a: "ⓐ",
   b: "ⓑ",

--- a/public/hint.js
+++ b/public/hint.js
@@ -127,14 +127,10 @@ function keysToKnowledge(keys) {
  */
 function combineKnowledge(k1, k2) {
   const newKnowledge = {
-    matches: [...new Set((k1.matches || []).concat(k2.matches || []))].sort(),
-    presents: [
-      ...new Set((k1.presents || []).concat(k2.presents || [])),
-    ].sort(),
-    misses: [...new Set((k1.misses || []).concat(k2.misses || []))].sort(),
-    availables: [
-      ...new Set((k1.availables || []).concat(k2.availables || [])),
-    ].sort(),
+    matches: [...new Set(k1.matches.concat(k2.matches))].sort(),
+    presents: [...new Set(k1.presents.concat(k2.presents))].sort(),
+    misses: [...new Set(k1.misses.concat(k2.misses))].sort(),
+    availables: [...new Set(k1.availables.concat(k2.availables))].sort(),
   };
 
   // If a letter is a match it can't also be present

--- a/public/puzzles.js
+++ b/public/puzzles.js
@@ -2416,7 +2416,7 @@ function getPuzzlesForDate(date) {
 
 /**
  * @param {Date} date
- * @param {string} difficulty
+ * @param {import("../types").Difficulty} difficulty
  * @returns {string}
  */
 function getPuzzleForDateAndDifficulty(date, difficulty) {
@@ -2619,7 +2619,7 @@ function getHolidayPuzzlePossibilities(date) {
 
 /**
  * @param {Date} date
- * @param {string} difficulty
+ * @param {import("../types").Difficulty} difficulty
  * @return {string | undefined}
  */
 function getHolidayPuzzle(date, difficulty) {
@@ -2735,7 +2735,11 @@ function guessesAsEmojis(guesses, theme) {
   const emojiTheme = emojiMatchThemes[theme] || randomEmojiMatchTheme();
   return guesses
     .map((guess) =>
-      guess.map((letter) => emojiTheme[letter.state] || "").join("")
+      guess
+        .map((letter) =>
+          letter.state == "pending" ? "" : emojiTheme[letter.state]
+        )
+        .join("")
     )
     .join("\n")
     .trim();

--- a/scripts/calendar.js
+++ b/scripts/calendar.js
@@ -26,7 +26,7 @@ for (let i = 0; i < days; i++) {
     date: date.toISOString().split("T")[0],
     ...puzzles,
     emojis: puzzleEmojis,
-    holiday: holiday?.name,
+    holiday: holiday && holiday.name,
   });
   date.setDate(date.getDate() + 1);
 }

--- a/scripts/dictionary.js
+++ b/scripts/dictionary.js
@@ -5,6 +5,9 @@ const axios = require("axios");
 const { emojis } = require("../public/emojis");
 const { words } = require("../public/puzzles");
 
+/**
+ * @param {string} letter
+ */
 async function getDefinitions(letter) {
   // @ts-ignore
   const result = await axios.get(
@@ -20,10 +23,13 @@ async function getDefinitions(letter) {
 // conclusion:
 // the definitions are too complicated, and synonyms too
 // need to write our own hints
-
+/**
+ * @param {string} letter
+ */
 async function main(letter) {
   const dictionary = await getDefinitions(letter);
 
+  /** @type {{[word: string]: {emoji: string, meaning?: string, hints: string[]}}} */
   const wordHints = {};
   const start = 1 + words.easy.indexOf("BELT"); // focus on after Feb 27
   const remaining = words.easy.slice(start, words.easy.length);

--- a/scripts/emojicheck.js
+++ b/scripts/emojicheck.js
@@ -47,14 +47,21 @@ const remaining = json
     return !takenKeys.find((taken) => keywords.includes(taken));
   });
 console.log(JSON.stringify(remaining, null, 2));
-const suggestions = remaining.reduce((mapping, item) => {
-  item.aliases
-    .concat(item.tags)
-    .filter((word) => word.length >= 4 && word.length <= 6)
-    .forEach((word) => {
-      mapping[word] = item.emoji;
-    });
-  return mapping;
-}, {});
+
+const suggestions = remaining.reduce(
+  /**
+   * @param {{[word: string]: string}} mapping
+   */
+  (mapping, item) => {
+    item.aliases
+      .concat(item.tags)
+      .filter((word) => word.length >= 4 && word.length <= 6)
+      .forEach((word) => {
+        mapping[word] = item.emoji;
+      });
+    return mapping;
+  },
+  {}
+);
 console.log(suggestions);
 console.log(remaining.length);

--- a/scripts/emojicheck.js
+++ b/scripts/emojicheck.js
@@ -16,7 +16,7 @@
 const { emojis } = require("../public/emojis");
 // get from https://raw.githubusercontent.com/github/gemoji/master/db/emoji.json
 // @ts-ignore
-const json = require("./emoji.json");
+const emojiJson = require("./emoji.json");
 
 const takenEmojis = Object.values(emojis);
 const takenKeys = Object.keys(emojis).map((key) => key.toLowerCase());
@@ -38,7 +38,7 @@ const categoryBlockList = [
   "Symbols",
 ];
 
-const remaining = json
+const remaining = emojiJson
   .filter((item) => !versionBlockList.includes(item.ios_version))
   .filter((item) => !categoryBlockList.includes(item.category))
   .filter((item) => !takenEmojis.includes(item.emoji))

--- a/scripts/emojicheck.js
+++ b/scripts/emojicheck.js
@@ -15,7 +15,9 @@
 
 const { emojis } = require("../public/emojis");
 // get from https://raw.githubusercontent.com/github/gemoji/master/db/emoji.json
-// @ts-ignore
+
+/** @type {{emoji: string, description: string, category: string, aliases: string[],
+ *          tags: string[], unicode_version: string, ios_version: string}[]} */
 const emojiJson = require("./emoji.json");
 
 const takenEmojis = Object.values(emojis);

--- a/scripts/emojicheck.js
+++ b/scripts/emojicheck.js
@@ -1,5 +1,8 @@
 // @ts-check
 
+const https = require("https");
+const { emojis } = require("../public/emojis");
+
 // constraints:
 // - 4-6 letter words
 // - prefer shorter where possible
@@ -12,58 +15,80 @@
 // TODO: should we allow multiple ways to unlock emoji?
 // eg "⚾️" could be PITCH, BUNT, CATCH, etc
 // also DOLL, DOLLS
+const url =
+  "https://raw.githubusercontent.com/github/gemoji/master/db/emoji.json";
 
-const { emojis } = require("../public/emojis");
-// get from https://raw.githubusercontent.com/github/gemoji/master/db/emoji.json
+https
+  .get(url, (res) => {
+    let jsonString = "";
+    res.on("data", (data) => {
+      jsonString += data;
+    });
 
-/** @type {{emoji: string, description: string, category: string, aliases: string[],
- *          tags: string[], unicode_version: string, ios_version: string}[]} */
-const emojiJson = require("./emoji.json");
+    res.on("end", function () {
+      if (res.statusCode === 200) {
+        try {
+          /**
+           * @type {{emoji: string, description: string, category: string, aliases: string[],
+           *         tags: string[], unicode_version: string, ios_version: string}[]}
+           */
+          const emojiJson = JSON.parse(jsonString);
 
-const takenEmojis = Object.values(emojis);
-const takenKeys = Object.keys(emojis).map((key) => key.toLowerCase());
+          const takenEmojis = Object.values(emojis);
+          const takenKeys = Object.keys(emojis).map((key) => key.toLowerCase());
 
-// too new
-// TODO: allow 13 now that we're using twemojis
-const versionBlockList = ["13.0", "13.1", "13.2", "14.0"];
+          // too new
+          // TODO: allow 13 now that we're using twemojis
+          const versionBlockList = ["13.0", "13.1", "13.2", "14.0"];
 
-const categoryBlockList = [
-  "Smileys & Emotion",
-  "Animals & Nature",
-  "Travel & Places",
-  // below have been thoroughly reviewed for version < 13:
-  "Activities",
-  "Flags",
-  "Food & Drink",
-  "Objects",
-  "People & Body",
-  "Symbols",
-];
+          const categoryBlockList = [
+            "Smileys & Emotion",
+            "Animals & Nature",
+            "Travel & Places",
+            // below have been thoroughly reviewed for version < 13:
+            "Activities",
+            "Flags",
+            "Food & Drink",
+            "Objects",
+            "People & Body",
+            "Symbols",
+          ];
 
-const remaining = emojiJson
-  .filter((item) => !versionBlockList.includes(item.ios_version))
-  .filter((item) => !categoryBlockList.includes(item.category))
-  .filter((item) => !takenEmojis.includes(item.emoji))
-  .filter((item) => {
-    const keywords = item.aliases.concat(item.tags);
-    return !takenKeys.find((taken) => keywords.includes(taken));
+          const remaining = emojiJson
+            .filter((item) => !versionBlockList.includes(item.ios_version))
+            .filter((item) => !categoryBlockList.includes(item.category))
+            .filter((item) => !takenEmojis.includes(item.emoji))
+            .filter((item) => {
+              const keywords = item.aliases.concat(item.tags);
+              return !takenKeys.find((taken) => keywords.includes(taken));
+            });
+          console.log(JSON.stringify(remaining, null, 2));
+
+          const suggestions = remaining.reduce(
+            /**
+             * @param {{[word: string]: string}} mapping
+             */
+            (mapping, item) => {
+              item.aliases
+                .concat(item.tags)
+                .filter((word) => word.length >= 4 && word.length <= 6)
+                .forEach((word) => {
+                  mapping[word] = item.emoji;
+                });
+              return mapping;
+            },
+            {}
+          );
+          console.log(suggestions);
+          console.log(remaining.length);
+        } catch (e) {
+          console.error(`Error parsing emoji JSON {e}`);
+        }
+      } else {
+        console.error(`Error downloding emojis from {url} - {res.statusCode}`);
+      }
+    });
+  })
+  .on("error", (e) => {
+    console.error(e);
   });
-console.log(JSON.stringify(remaining, null, 2));
-
-const suggestions = remaining.reduce(
-  /**
-   * @param {{[word: string]: string}} mapping
-   */
-  (mapping, item) => {
-    item.aliases
-      .concat(item.tags)
-      .filter((word) => word.length >= 4 && word.length <= 6)
-      .forEach((word) => {
-        mapping[word] = item.emoji;
-      });
-    return mapping;
-  },
-  {}
-);
-console.log(suggestions);
-console.log(remaining.length);

--- a/scripts/puzzlestats.js
+++ b/scripts/puzzlestats.js
@@ -4,11 +4,17 @@ const { words } = require("../public/puzzles");
 
 const allWords = words.easy.concat(words.medium).concat(words.hard);
 
-const frequency = allWords.reduce((memo, word) => {
-  const letters = word.split("");
-  letters.forEach((letter) => (memo[letter] = 1 + (memo[letter] || 0)));
-  return memo;
-}, {});
+const frequency = allWords.reduce(
+  /**
+   * @param {{[word: string]: number}} memo
+   */
+  (memo, word) => {
+    const letters = word.split("");
+    letters.forEach((letter) => (memo[letter] = 1 + (memo[letter] || 0)));
+    return memo;
+  },
+  {}
+);
 
 const sorted = Object.keys(frequency)
   .map((key) => ({ letter: key, count: frequency[key] }))

--- a/test/hint.test.js
+++ b/test/hint.test.js
@@ -93,17 +93,11 @@ describe("hint", () => {
         misses: [],
         availables: [],
       };
-      const partial1b = {
-        presents: ["A"],
-      };
       const partial2 = {
         matches: [],
         presents: [],
         misses: ["R", "S", "T"],
         availables: [],
-      };
-      const partial2b = {
-        misses: ["R", "S", "T"],
       };
       const expected1 = {
         matches: [],
@@ -122,10 +116,6 @@ describe("hint", () => {
       expect(combineKnowledge(partial1, noKnowledge)).toEqual(expected1);
       expect(combineKnowledge(noKnowledge, partial2)).toEqual(expected2);
       expect(combineKnowledge(partial2, noKnowledge)).toEqual(expected2);
-      expect(combineKnowledge(noKnowledge, partial1b)).toEqual(expected1);
-      expect(combineKnowledge(partial1b, noKnowledge)).toEqual(expected1);
-      expect(combineKnowledge(noKnowledge, partial2b)).toEqual(expected2);
-      expect(combineKnowledge(partial2b, noKnowledge)).toEqual(expected2);
 
       expect(
         combineKnowledge(combineKnowledge(noKnowledge, partial1), partial2)
@@ -151,9 +141,15 @@ describe("hint", () => {
         label: "guess",
         state: "unavailable",
       });
-      keys.find((key) => key.label === "T").state = "present";
-      keys.find((key) => key.label === "E").state = "miss";
-      keys.find((key) => key.label === "R").state = "match";
+      const tKey = keys.find((key) => key.label === "T");
+      const eKey = keys.find((key) => key.label === "E");
+      const rKey = keys.find((key) => key.label === "R");
+      if (!tKey || !eKey || !rKey) {
+        throw Error("Unable to find key");
+      }
+      tKey.state = "present";
+      eKey.state = "miss";
+      rKey.state = "match";
 
       const knowledge = keysToKnowledge(keys);
 
@@ -323,7 +319,12 @@ describe("hint", () => {
         const hint = getHint(target, knowledge, settings, 4);
         expect(hint).toHaveProperty("misses", expectedMisses);
 
-        knowledge = combineKnowledge(knowledge, { misses: hint.misses });
+        knowledge = combineKnowledge(knowledge, {
+          misses: (hint && hint.misses) || [],
+          matches: [],
+          presents: [],
+          availables: [],
+        });
       }
 
       const lastHint = getHint(target, knowledge, settings, 5);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,30 +1,24 @@
 {
-  "include": [
-    "public/**/*",
-    "scripts/**/*",
-  ],
-  "exclude": [
-    "public/amplitude.js",
-    "public/mobileCheck.js"
-  ],
+  "include": ["public/**/*", "scripts/**/*"],
+  "exclude": ["public/amplitude.js", "public/mobileCheck.js"],
   "compilerOptions": {
-    "target": "ES2019",                               /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES2019" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "module": "ESNext",
 
-    "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./" /* Specify the root folder within your source files. */,
     "moduleResolution": "node",
-    "resolveJsonModule": true,                        /* Enable importing .json files. */
+    "resolveJsonModule": true /* Enable importing .json files. */,
 
-    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
+    "checkJs": true /* Enable error reporting in type-checked JavaScript files. */,
 
-    "declaration": false,                             /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    "outDir": "./dist",                               /* Specify an output folder for all emitted files. */
-    "forceConsistentCasingInFileNames": true,         /* Ensure that casing is correct in imports. */
-    
-    "strict": true,                                   
+    "declaration": false /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    "strict": true,
     // TODO: enable below
-    "noImplicitAny": false,                           
-    "strictNullChecks": false,
+    "noImplicitAny": true,
+    "strictNullChecks": true
   }
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -32,10 +32,10 @@ export type KeyState = {
 };
 
 export type Knowledge = {
-  matches?: string[];
-  presents?: string[];
-  misses?: string[];
-  availables?: string[];
+  matches: string[];
+  presents: string[];
+  misses: string[];
+  availables: string[];
 };
 
 export type Settings = {

--- a/types.d.ts
+++ b/types.d.ts
@@ -4,6 +4,8 @@ declare global {
   }
 }
 
+export type Difficulty = "easy" | "medium" | "hard";
+
 export type GuessState = "pending" | "match" | "present" | "miss";
 
 export type LetterGuess = {


### PR DESCRIPTION
Follow up on #136 
Turn on `noImplicitAny` and `strictNullChecks`.

The only big code change was to Knowledge which no longer allows partial definitions. Cleans up the code and makes the types simpler, but need to ensure we handle backward compatibility with saved state.

Also changed scripts/emojichec.js to download the file instead of relying on a local (but not checked in) version.

We do have a big typeschecking hole in index.html, but otherwise things look great.