### PR TITLE
Minor: Move the cursor off the page when solving a puzzle

### DIFF
--- a/index.html
+++ b/index.html
@@ -639,6 +639,9 @@
             if (!this.solved && !this.failed) {
               this.cursor = this.cursorReverse ? this.target.length - 1 : 0;
               this.prepareHint();
+            } else if (this.solved) {
+              // Move cursor off the page
+              this.cursor = this.target.length;
             }
             this.updateControls();
             this.saveGameState();


### PR DESCRIPTION
Minor fix. Normally it is off the page, unless you go back and enter an earlier character in cursor mode. Doesn't break anything, but looks weird if left there on solved puzzles.

Before:
<img width="636" alt="Screenshot 2024-01-05 at 11 57 14 AM" src="https://github.com/canadianveggie/spellie/assets/513961/9f72311a-811f-4580-9081-59acb27a5462">


After:

<img width="671" alt="Screenshot 2024-01-05 at 11 57 41 AM" src="https://github.com/canadianveggie/spellie/assets/513961/f8de75ae-6a37-4801-8dbf-64d0497df4b8">
