### PR TITLE
Show found emojis in hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -935,7 +935,12 @@
             });
           }
 
-          const blanks = Array(collection.hint.word.length).fill("_ ").join("");
+          let blanks = Array(collection.hint.word.length).fill("_ ").join("");
+          const foundEmoji = this.unlockedEmojis.some((entry) => entry.word === collection.hint.word);
+          if (foundEmoji) {
+            // If the emoji is since found, show the word in the hint
+            blanks = collection.hint.word;
+          }
           this.showNotice(`${blanks} = #${collection.hint.emoji}#`, "hint");
         },
         showHint() {


### PR DESCRIPTION
If someone finds an emoji after it is hinted, it will show up in the hint next time it is displayed.
Change suggested by Astrid.

New hint:
<img width="582" alt="Screenshot 2024-01-05 at 11 52 50 AM" src="https://github.com/canadianveggie/spellie/assets/513961/a01a93c6-f42b-49c9-9afd-2102cd1b65b4">

Found after hint:
<img width="583" alt="Screenshot 2024-01-05 at 11 53 42 AM" src="https://github.com/canadianveggie/spellie/assets/513961/990eab2b-bd5b-427e-8b39-a3198ff632b2">
