### PR TITLE
Allow APRIL in dictionary

### DIFF
--- a/public/dictionary.js
+++ b/public/dictionary.js
@@ -6061,6 +6061,7 @@ const validWords = new Set([
   "APPUI",
   "APPUY",
   "APRES",
+  "APRIL",
   "APRON",
   "APSES",
   "APSIS",


### PR DESCRIPTION
Because I messed up the April Fools puzzle.

Will add a test case to insure puzzles are in the dictionary later.