### PR TITLE
Fix EMAIL emoji

### DIFF
--- a/public/emojis.js
+++ b/public/emojis.js
@@ -208,7 +208,7 @@ const emojis = {
   EGGS: "🥚",
   EIGHT: "8️⃣",
   ELVEN: "🧝",
-  EMAIL: "💌",
+  EMAIL: "📧",
   EURO: "💶",
   EVIL: "🦹",
   EYES: "👀",


### PR DESCRIPTION
Shouldn't be love letter...

This is a safe change to make as we only store the name of the emoji, not the symbol, in game state.