### PR TITLE
Get rid of the amplitude error_encountered for ResizeObserver undefined

### DIFF
--- a/index.html
+++ b/index.html
@@ -1349,9 +1349,7 @@
 
     function initScalingFontSize() {
       if ("ResizeObserver" in window === false) {
-        amplitude.getInstance().logEvent("error_encountered", {
-          message: "ResizeObserver not supported",
-        });
+        // Old browser without a ResizeObserver, leave font size as defaults
         return;
       }
 


### PR DESCRIPTION
Logging this error doesn't tell us much. We handle it gracefully enough. Removing this might give us some breathing room in Amplitude, where we're close to the limits of what we can send in our free account.

I noticed in Amplitude a bunch of sessions that only have this error in them. Usually caused by people on an old iphone/ipad (using Mobile Safari 12). If 
![Screenshot 2024-09-27 at 9 40 20 AM](https://github.com/user-attachments/assets/770fb6c3-7a49-4a5b-8659-cfa1da966fb6)
