### PR TITLE
Ignore errors that come from 3rd party code

### DIFF
--- a/index.html
+++ b/index.html
@@ -1390,7 +1390,7 @@
 
     window.onerror = function onError(message, url, lineNo, columnNo, error) {
       try {
-        if (url && url.includes("extension://")) {
+        if (!url || url.includes("extension://")) {
           // Ignore problems with extensions
           return false;
         }


### PR DESCRIPTION
The most common error we get is:
error: null
message: "Script error."
source: ":0:0"

which we can't do anything about.

So ignore them. This should reduce a small percentage of wasted MAU in our Amplitude account - users that only ever log an error and then move on.