### PR TITLE
Add a Stats page

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,6 +293,48 @@
           <button class="hint-button" @click="showEmojiHint">Need a hint? 🤔</button>
         </div>
       </div>
+      <div class="stats-content" x-show="page === '#stats'" x-cloak>
+        <div class="subhead">
+          <h1>Stats</h1>
+          <div>
+            <a x-bind:href="gameUrl" class="close-link">
+              <i class="material-icons">close</i>
+            </a>
+          </div>
+        </div>
+
+        <p x-text="statsSummary && statsSummary.textHeader"></p>
+
+        <section>
+          <h2>Number of Guesses to Solve</h2>
+          <template x-if="statsSummary && statsSummary.guessHistogram">
+            <div class="stats-guess-histograms">
+              <template x-for="d in ['easy', 'medium', 'hard']" :key="d">
+                <div class="stats-histogram-block">
+                  <h3 class="stats-histogram-difficulty" x-text="d.charAt(0).toUpperCase() + d.slice(1)"></h3>
+                  <div class="stats-histogram-rows">
+                    <template x-for="row in statsSummary.guessHistogram[d]" :key="row.label">
+                      <div class="stats-difficulty-row stats-histogram-row">
+                        <span class="stats-guess-label"
+                          ><span x-text="row.label"></span> <span x-text="row.emoji"></span
+                        ></span>
+                        <div class="stats-bar-wrap">
+                          <div
+                            class="stats-bar stats-bar-guess"
+                            :style="`width: ${statsSummary.maxGuessCount ? (100 * row.count / statsSummary.maxGuessCount) : 0}%; visibility: ${row.count > 0 ? 'visible' : 'hidden'}`"
+                          ></div>
+                        </div>
+                        <span class="stats-difficulty-count" x-text="row.count"></span>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </template>
+          <p x-show="statsSummary && !statsSummary.guessHistogram" x-cloak>Loading…</p>
+        </section>
+      </div>
       <div class="archive-content" x-show="page === '#archive'" x-cloak>
         <div class="subhead">
           <h1>Archive</h1>
@@ -466,45 +508,6 @@
               </label>
             </div>
           </template>
-        </section>
-      </div>
-      <div class="stats-content" x-show="page === '#stats'" x-cloak>
-        <div class="subhead">
-          <h1>Stats</h1>
-          <div>
-            <a x-bind:href="gameUrl" class="close-link">
-              <i class="material-icons">close</i>
-            </a>
-          </div>
-        </div>
-        <section>
-          <h2>By Difficulty</h2>
-          <template x-if="statsSummary && statsSummary.guessHistogram">
-            <div class="stats-guess-histograms">
-              <template x-for="d in ['easy', 'medium', 'hard']" :key="d">
-                <div class="stats-histogram-block">
-                  <h3 class="stats-histogram-difficulty" x-text="d.charAt(0).toUpperCase() + d.slice(1)"></h3>
-                  <div class="stats-histogram-rows">
-                    <template x-for="row in statsSummary.guessHistogram[d]" :key="row.label">
-                      <div class="stats-difficulty-row stats-histogram-row">
-                        <span class="stats-guess-label"
-                          ><span x-text="row.label"></span> <span x-text="row.emoji"></span
-                        ></span>
-                        <div class="stats-bar-wrap">
-                          <div
-                            class="stats-bar stats-bar-guess"
-                            :style="`width: ${statsSummary.maxGuessCount ? (100 * row.count / statsSummary.maxGuessCount) : 0}%; visibility: ${row.count > 0 ? 'visible' : 'hidden'}`"
-                          ></div>
-                        </div>
-                        <span class="stats-difficulty-count" x-text="row.count"></span>
-                      </div>
-                    </template>
-                  </div>
-                </div>
-              </template>
-            </div>
-          </template>
-          <p x-show="statsSummary && !statsSummary.guessHistogram" x-cloak>Loading…</p>
         </section>
       </div>
       <div
@@ -1210,21 +1213,29 @@
             return { label: `${i + 1}`, emoji };
           });
           const guessHistogram = {};
+          let maxCompleted = 1;
+          let maxGuessCount = 1;
           DIFFICULTIES.forEach((d) => {
             const stats = statistics[d] || {};
             byDifficulty[d] = { completed: stats.success, played: stats.success + stats.fail };
+            maxCompleted = Math.max(maxCompleted, stats.success);
             total += stats.success;
-            guessHistogram[d] = guessRowLabels.map((row, i) => {
+            guessHistogram[d] = [];
+            guessRowLabels.forEach((row, i) => {
               const count = stats.guesses[i + 1];
-              return { label: row.label, emoji: row.emoji, count };
+              guessHistogram[d][i] = { label: row.label, emoji: row.emoji, count };
+              maxGuessCount = Math.max(maxGuessCount, count);
             });
           });
-          const maxCompleted = Math.max(1, ...DIFFICULTIES.map((d) => byDifficulty[d].completed));
-          const maxGuessCount = Math.max(
-            1,
-            ...DIFFICULTIES.map((d) => Math.max(...guessHistogram[d].map((h) => h.count)))
-          );
-          this.statsSummary = { total, byDifficulty, maxCompleted, guessHistogram, maxGuessCount };
+
+          let textHeader = `You've completed ${total} games of Spellie. 👏`;
+          if (total === 0) {
+            textHeader = "Keep track of your progress as you finish each game of Spellie.";
+          } else if (total === 1) {
+            textHeader = "Congratulations on finishing your first game of Spellie.";
+          }
+
+          this.statsSummary = { total, byDifficulty, maxCompleted, guessHistogram, maxGuessCount, textHeader };
         },
         levelEnd() {
           amplitude.getInstance().logEvent("level_end", {

--- a/index.html
+++ b/index.html
@@ -61,6 +61,9 @@
             ></span>
             <i class="material-icons">collections</i>
           </a>
+          <a href="#stats" class="nav-link" title="Statistics">
+            <i class="material-icons">bar_chart</i>
+          </a>
           <a href="#settings" class="nav-link" title="Settings">
             <i class="material-icons">settings</i>
           </a>
@@ -475,31 +478,7 @@
           </div>
         </div>
         <section>
-          <h2>Total games completed</h2>
-          <template x-if="statsSummary">
-            <div class="stats-totals">
-              <p class="stats-total-number" x-text="statsSummary.total">games won</p>
-              <p class="stats-total-label">games won</p>
-              <div class="stats-by-difficulty" aria-label="Games completed by difficulty">
-                <template x-for="d in ['easy', 'medium', 'hard']" :key="d">
-                  <div class="stats-difficulty-row">
-                    <span class="stats-difficulty-name" x-text="d.charAt(0).toUpperCase() + d.slice(1)"></span>
-                    <div class="stats-bar-wrap">
-                      <div
-                        class="stats-bar"
-                        :style="`width: ${statsSummary.maxCompleted ? (100 * statsSummary.byDifficulty[d].completed / statsSummary.maxCompleted) : 0}%`"
-                      ></div>
-                    </div>
-                    <span class="stats-difficulty-count" x-text="statsSummary.byDifficulty[d].completed"></span>
-                  </div>
-                </template>
-              </div>
-            </div>
-          </template>
-          <p x-show="!statsSummary" x-cloak>Loading…</p>
-        </section>
-        <section>
-          <h2>Results</h2>
+          <h2>By Difficulty</h2>
           <template x-if="statsSummary && statsSummary.guessHistogram">
             <div class="stats-guess-histograms">
               <template x-for="d in ['easy', 'medium', 'hard']" :key="d">
@@ -514,8 +493,7 @@
                         <div class="stats-bar-wrap">
                           <div
                             class="stats-bar stats-bar-guess"
-                            :class="{ 'stats-bar-fail': row.label === 'X' }"
-                            :style="`width: ${statsSummary.maxGuessCount ? (100 * row.count / statsSummary.maxGuessCount) : 0}%`"
+                            :style="`width: ${statsSummary.maxGuessCount ? (100 * row.count / statsSummary.maxGuessCount) : 0}%; visibility: ${row.count > 0 ? 'visible' : 'hidden'}`"
                           ></div>
                         </div>
                         <span class="stats-difficulty-count" x-text="row.count"></span>
@@ -697,10 +675,6 @@
         updatePage(page) {
           this.page = page;
           this.updateTitle();
-          if (page === "#stats") {
-            this.loadCollection();
-            this.loadStatsSummary();
-          }
         },
         addLetter(letterState) {
           if (this.solved || this.failed) {
@@ -946,11 +920,11 @@
             return this.cursor + delta;
           }
         },
+        get victoryEmojis() {
+          return this.isAprilFools() ? ["👽", "🦸‍♀️", "😻", "🥸", "🍪", "🥵"] : ["🏆", "🤩", "🥳", "😁", "🙂", "👍"];
+        },
         get victoryEmoji() {
-          const victoryEmojis = this.isAprilFools()
-            ? ["👽", "🦸‍♀️", "😻", "🥸", "🍪", "🥵"]
-            : ["🏆", "🤩", "🥳", "😁", "🙂", "👍"];
-          return victoryEmojis[this.currentGuessIndex - 1] || victoryEmojis[victoryEmojis.length - 1];
+          return this.victoryEmojis[this.currentGuessIndex - 1] || this.victoryEmojis[this.victoryEmojis.length - 1];
         },
         /** First letter provided free for 4-letter words */
         prepareFreebie() {
@@ -1232,22 +1206,16 @@
           const statistics = this.getFromLocalStorage("statistics", DEFAULT_STATISTICS);
           const byDifficulty = {};
           let total = 0;
-          const guessRowLabels = [
-            { label: "1", emoji: "🏆" },
-            { label: "2", emoji: "🤩" },
-            { label: "3", emoji: "🥳" },
-            { label: "4", emoji: "😁" },
-            { label: "5", emoji: "🙂" },
-            { label: "6", emoji: "👍" },
-            { label: "X", emoji: "🙅" },
-          ];
+          const guessRowLabels = this.victoryEmojis.map((emoji, i) => {
+            return { label: `${i + 1}`, emoji };
+          });
           const guessHistogram = {};
           DIFFICULTIES.forEach((d) => {
             const stats = statistics[d] || {};
             byDifficulty[d] = { completed: stats.success, played: stats.success + stats.fail };
             total += stats.success;
             guessHistogram[d] = guessRowLabels.map((row, i) => {
-              const count = row.label === "X" ? stats.fail : stats.guesses[i + 1];
+              const count = stats.guesses[i + 1];
               return { label: row.label, emoji: row.emoji, count };
             });
           });
@@ -1295,6 +1263,7 @@
             statistics[this.difficulty].fail += 1;
           }
           localStorage.setItem("statistics", JSON.stringify(statistics));
+          this.loadStatsSummary();
         },
         get lockedEmojis() {
           return this.emojiCollection.filter((e) => !e.unlocked);

--- a/index.html
+++ b/index.html
@@ -465,6 +465,28 @@
           </template>
         </section>
       </div>
+      <div class="stats-content" x-show="page === '#stats'" x-cloak>
+        <div class="subhead">
+          <h1>Stats</h1>
+          <div>
+            <a x-bind:href="gameUrl" class="close-link">
+              <i class="material-icons">close</i>
+            </a>
+          </div>
+        </div>
+        <section>
+          <h2>Total games completed</h2>
+          <p><!-- placeholder --></p>
+        </section>
+        <section>
+          <h2>Guesses per game</h2>
+          <p>Histogram by difficulty (placeholder).</p>
+        </section>
+        <section>
+          <h2>Emojis unlocked over time</h2>
+          <p>Timeline view (placeholder).</p>
+        </section>
+      </div>
       <div
         x-data="noticesHandler()"
         class="notice"
@@ -618,6 +640,7 @@
             "#archive": "Spellie | Archive",
             "#collection": "Spellie | Emoji Collection",
             "#settings": "Spellie | Settings",
+            "#stats": "Spellie | Stats",
             "#about": "Spellie | About",
           };
           if (titles[this.page]) {

--- a/index.html
+++ b/index.html
@@ -476,15 +476,57 @@
         </div>
         <section>
           <h2>Total games completed</h2>
-          <p><!-- placeholder --></p>
+          <template x-if="statsSummary">
+            <div class="stats-totals">
+              <p class="stats-total-number" x-text="statsSummary.total">games won</p>
+              <p class="stats-total-label">games won</p>
+              <div class="stats-by-difficulty" aria-label="Games completed by difficulty">
+                <template x-for="d in ['easy', 'medium', 'hard']" :key="d">
+                  <div class="stats-difficulty-row">
+                    <span class="stats-difficulty-name" x-text="d.charAt(0).toUpperCase() + d.slice(1)"></span>
+                    <div class="stats-bar-wrap">
+                      <div
+                        class="stats-bar"
+                        :style="`width: ${statsSummary.maxCompleted ? (100 * statsSummary.byDifficulty[d].completed / statsSummary.maxCompleted) : 0}%`"
+                      ></div>
+                    </div>
+                    <span class="stats-difficulty-count" x-text="statsSummary.byDifficulty[d].completed"></span>
+                  </div>
+                </template>
+              </div>
+            </div>
+          </template>
+          <p x-show="!statsSummary" x-cloak>Loading…</p>
         </section>
         <section>
-          <h2>Guesses per game</h2>
-          <p>Histogram by difficulty (placeholder).</p>
-        </section>
-        <section>
-          <h2>Emojis unlocked over time</h2>
-          <p>Timeline view (placeholder).</p>
+          <h2>Results</h2>
+          <template x-if="statsSummary && statsSummary.guessHistogram">
+            <div class="stats-guess-histograms">
+              <template x-for="d in ['easy', 'medium', 'hard']" :key="d">
+                <div class="stats-histogram-block">
+                  <h3 class="stats-histogram-difficulty" x-text="d.charAt(0).toUpperCase() + d.slice(1)"></h3>
+                  <div class="stats-histogram-rows">
+                    <template x-for="row in statsSummary.guessHistogram[d]" :key="row.label">
+                      <div class="stats-difficulty-row stats-histogram-row">
+                        <span class="stats-guess-label"
+                          ><span x-text="row.label"></span> <span x-text="row.emoji"></span
+                        ></span>
+                        <div class="stats-bar-wrap">
+                          <div
+                            class="stats-bar stats-bar-guess"
+                            :class="{ 'stats-bar-fail': row.label === 'X' }"
+                            :style="`width: ${statsSummary.maxGuessCount ? (100 * row.count / statsSummary.maxGuessCount) : 0}%`"
+                          ></div>
+                        </div>
+                        <span class="stats-difficulty-count" x-text="row.count"></span>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </template>
+          <p x-show="statsSummary && !statsSummary.guessHistogram" x-cloak>Loading…</p>
         </section>
       </div>
       <div
@@ -632,6 +674,7 @@
           misses: [],
           availables: [],
         },
+        statsSummary: {},
         updateTitle() {
           const titles = {
             "#easy": "Spellie | Easy",
@@ -654,6 +697,10 @@
         updatePage(page) {
           this.page = page;
           this.updateTitle();
+          if (page === "#stats") {
+            this.loadCollection();
+            this.loadStatsSummary();
+          }
         },
         addLetter(letterState) {
           if (this.solved || this.failed) {
@@ -1017,6 +1064,7 @@
           this.loadGameState();
           this.loadCollection();
           this.loadArchive();
+          this.loadStatsSummary();
           this.updateTitle();
         },
         formatGameStateVariable(difficulty, puzzleId) {
@@ -1179,6 +1227,36 @@
             }));
           const identifyEmojis = new amplitude.Identify().set("emojiCount", this.unlockedEmojis.length);
           amplitude.getInstance().identify(identifyEmojis);
+        },
+        loadStatsSummary() {
+          const statistics = this.getFromLocalStorage("statistics", DEFAULT_STATISTICS);
+          const byDifficulty = {};
+          let total = 0;
+          const guessRowLabels = [
+            { label: "1", emoji: "🏆" },
+            { label: "2", emoji: "🤩" },
+            { label: "3", emoji: "🥳" },
+            { label: "4", emoji: "😁" },
+            { label: "5", emoji: "🙂" },
+            { label: "6", emoji: "👍" },
+            { label: "X", emoji: "🙅" },
+          ];
+          const guessHistogram = {};
+          DIFFICULTIES.forEach((d) => {
+            const stats = statistics[d] || {};
+            byDifficulty[d] = { completed: stats.success, played: stats.success + stats.fail };
+            total += stats.success;
+            guessHistogram[d] = guessRowLabels.map((row, i) => {
+              const count = row.label === "X" ? stats.fail : stats.guesses[i + 1];
+              return { label: row.label, emoji: row.emoji, count };
+            });
+          });
+          const maxCompleted = Math.max(1, ...DIFFICULTIES.map((d) => byDifficulty[d].completed));
+          const maxGuessCount = Math.max(
+            1,
+            ...DIFFICULTIES.map((d) => Math.max(...guessHistogram[d].map((h) => h.count)))
+          );
+          this.statsSummary = { total, byDifficulty, maxCompleted, guessHistogram, maxGuessCount };
         },
         levelEnd() {
           amplitude.getInstance().logEvent("level_end", {

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
             ></span>
             <i class="material-icons">collections</i>
           </a>
-          <a href="#stats" class="nav-link" title="Statistics">
+          <a href="#stats" class="nav-link" title="Stats">
             <i class="material-icons">bar_chart</i>
           </a>
           <a href="#settings" class="nav-link" title="Settings">

--- a/public/main.css
+++ b/public/main.css
@@ -651,10 +651,7 @@ main {
   background: var(--color-match);
   border-radius: 4px;
   transition: width 0.3s ease;
-  border: 1px solid #000;
-}
-.stats-bar-fail {
-  background: var(--color-present);
+  border: 1px solid color-mix(in srgb, var(--color-match) 85%, black);
 }
 .stats-difficulty-count {
   text-align: right;

--- a/public/main.css
+++ b/public/main.css
@@ -641,7 +641,7 @@ main {
 }
 .stats-bar-wrap {
   height: 1.25rem;
-  background: var(--color-miss, rgba(0, 0, 0, 0.08));
+  background: var(--color-miss, rgb(0 0 0 / 0.08));
   border-radius: 4px;
   overflow: hidden;
 }

--- a/public/main.css
+++ b/public/main.css
@@ -612,6 +612,85 @@ main {
   text-decoration: underline;
 }
 
+.stats-totals {
+  margin-top: 0.5rem;
+}
+.stats-total-number {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 0;
+  line-height: 1.2;
+}
+.stats-total-label {
+  margin: 0 0 1rem;
+  color: var(--color-neutral-20);
+}
+.stats-by-difficulty {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.stats-difficulty-row {
+  display: grid;
+  grid-template-columns: 4.5em 1fr 2.5em;
+  align-items: center;
+  gap: 0.5rem;
+}
+.stats-difficulty-name {
+  font-weight: 600;
+}
+.stats-bar-wrap {
+  height: 1.25rem;
+  background: var(--color-miss, rgba(0, 0, 0, 0.08));
+  border-radius: 4px;
+  overflow: hidden;
+}
+.stats-bar {
+  height: 100%;
+  min-width: 2px;
+  background: var(--color-match);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+  border: 1px solid #000;
+}
+.stats-bar-fail {
+  background: var(--color-present);
+}
+.stats-difficulty-count {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.stats-guess-histograms {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-top: 0.5rem;
+}
+.stats-histogram-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.stats-histogram-difficulty {
+  font-size: 1rem;
+  margin: 0 0 0.25rem;
+  font-weight: 600;
+}
+.stats-histogram-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.stats-histogram-row.stats-difficulty-row {
+  grid-template-columns: 3em 1fr 2.5em;
+}
+.stats-guess-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+}
+
 .notice {
   position: fixed;
   top: 8%;

--- a/public/main.css
+++ b/public/main.css
@@ -59,7 +59,8 @@ body {
 body.page-about,
 body.page-archive,
 body.page-collection,
-body.page-settings {
+body.page-settings,
+body.page-stats {
   background: var(--color-page-bg);
 }
 


### PR DESCRIPTION
Add the start of a stats page. I played around with some other metrics (games completed by difficulty, emojis unlocked, etc) but this seemed the simplest to start.

Example:
<img width="602" height="796" alt="Screenshot 2026-03-20 at 1 43 03 PM" src="https://github.com/user-attachments/assets/a03be27c-7f94-4633-a135-5786d4ee3237" />

With no games completed:
<img width="599" height="806" alt="Screenshot 2026-03-20 at 1 43 11 PM" src="https://github.com/user-attachments/assets/7d23fdbb-5480-4713-ba06-f64f47d0316c" />

With high-contrast enabled:
<img width="597" height="811" alt="Screenshot 2026-03-20 at 1 43 25 PM" src="https://github.com/user-attachments/assets/66d3d9b8-6a2a-4781-9552-25588da00e1c" />
